### PR TITLE
SmartCast: improve D/W Dervish build skill logic

### DIFF
--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Attack.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Attack.au3
@@ -2052,7 +2052,7 @@ Func BestTarget_VictoriousSweep($a_f_AggroRange)
 	; Melee Attack. If this attack hits, you deal +5...21...25 damage. If target foe has less Health than you, you gain 30...70...80 Health.
 	; Concise description
 	; Melee Attack. Deals +5...21...25 damage. You gain 30...70...80 Health for each foe you hit that has less Health than you.
-	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1489 - $GC_I_SKILL_ID_IRRESISTIBLE_SWEEP
@@ -2858,7 +2858,7 @@ Func BestTarget_ZealousSweep($a_f_AggroRange)
 	; Scythe Attack. If this attack hits, you deal +5...17...20 damage. You gain 3 Energy and 1 adrenaline for each foe you hit.
 	; Concise description
 	; Scythe Attack. Deals +5...17...20 damage. You gain 3 Energy and 1 adrenaline for each foe you hit.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2074 - $GC_I_SKILL_ID_CHEST_THUMPER
@@ -2906,7 +2906,7 @@ Func BestTarget_WhirlwindAttack($a_f_AggroRange)
 	; This article is about the Nightfall skill. For the temporarily available Bonus Mission Pack skill, see Whirlwind Attack (Turai Ossa).
 	; Concise description
 	; green; font-weight: bold;">13...20
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2111 - $GC_I_SKILL_ID_VAMPIRISM_ATTACK

--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Enchantment.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Enchantment.au3
@@ -2427,6 +2427,7 @@ EndFunc
 ; Skill ID: 1510 - $GC_I_SKILL_ID_SAND_SHARDS
 Func CanUse_SandShards()
 	If Anti_Enchantment() Then Return False
+	If UAI_PlayerHasEffect($GC_I_SKILL_ID_SAND_SHARDS) Then Return False
 	If UAI_CountAgents(-2, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy") <= 1 Then Return False
 	Return True
 EndFunc
@@ -2863,14 +2864,11 @@ EndFunc
 ; Skill ID: 1759 - $GC_I_SKILL_ID_VOW_OF_STRENGTH
 Func CanUse_VowOfStrength()
 	If Anti_Enchantment() Then Return False
-
-	Local $l_b_SkillSlot = Skill_GetSlotByID($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS)
-	Local $l_b_HasEffect = UAI_GetPlayerEffectInfo($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS, $GC_UAI_EFFECT_TimeRemaining) > 500
-
-	If $l_b_SkillSlot > 0 Then
-		If Not $l_b_HasEffect Then
-			Skill_UseSkill($l_b_SkillSlot)
-		EndIf
+	If UAI_PlayerHasEffect($GC_I_SKILL_ID_VOW_OF_STRENGTH) Then Return False
+	; If Extend Enchantments is in the bar and not currently active, wait for it (it will cast first via slot order)
+	Local $l_i_ExtendSlot = Skill_GetSlotByID($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS)
+	If $l_i_ExtendSlot > 0 Then
+		If Not UAI_PlayerHasEffect($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS) Then Return False
 	EndIf
 	Return True
 EndFunc

--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Shout.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Shout.au3
@@ -839,6 +839,7 @@ EndFunc
 
 Func CanUse_DodgeThis()
 	If Anti_Shout() Then Return False
+	If UAI_PlayerHasEffect($GC_I_SKILL_ID_DODGE_THIS) Then Return False
 	Return True
 EndFunc
 
@@ -852,6 +853,7 @@ EndFunc
 
 Func CanUse_IAmTheStrongest()
 	If Anti_Shout() Then Return False
+	If UAI_PlayerHasEffect($GC_I_SKILL_ID_I_AM_THE_STRONGEST) Then Return False
 	Return True
 EndFunc
 

--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Skill16.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Skill16.au3
@@ -214,10 +214,11 @@ EndFunc
 ; Skill ID: 1508 - $GC_I_SKILL_ID_EXTEND_ENCHANTMENTS
 Func CanUse_ExtendEnchantments()
 	If UAI_PlayerHasEffect($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS) Then Return False
-	; Only useful to boost VoS — skip if VoS not in bar or already active
+	; If VoS is in the bar, wait until VoS is not active (cast Extend just before VoS)
 	Local $l_i_VoSSlot = Skill_GetSlotByID($GC_I_SKILL_ID_VOW_OF_STRENGTH)
-	If $l_i_VoSSlot = 0 Then Return False
-	If UAI_PlayerHasEffect($GC_I_SKILL_ID_VOW_OF_STRENGTH) Then Return False
+	If $l_i_VoSSlot > 0 Then
+		If UAI_PlayerHasEffect($GC_I_SKILL_ID_VOW_OF_STRENGTH) Then Return False
+	EndIf
 	Return True
 EndFunc
 

--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Skill16.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Skill16.au3
@@ -213,6 +213,11 @@ EndFunc
 
 ; Skill ID: 1508 - $GC_I_SKILL_ID_EXTEND_ENCHANTMENTS
 Func CanUse_ExtendEnchantments()
+	If UAI_PlayerHasEffect($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS) Then Return False
+	; Only useful to boost VoS — skip if VoS not in bar or already active
+	Local $l_i_VoSSlot = Skill_GetSlotByID($GC_I_SKILL_ID_VOW_OF_STRENGTH)
+	If $l_i_VoSSlot = 0 Then Return False
+	If UAI_PlayerHasEffect($GC_I_SKILL_ID_VOW_OF_STRENGTH) Then Return False
 	Return True
 EndFunc
 


### PR DESCRIPTION
This PR improves the SmartCast behavior for several Dervish skills. Changes were validated against official wiki mechanics before implementation.

**Target selection (scythe attacks)**
- BestTarget_VictoriousSweep, BestTarget_ZealousSweep, BestTarget_WhirlwindAttack: switched from nearest-enemy or stub (Return 0) to UAI_GetBestAOETarget with adjacent range. Scythes hit the target and all foes adjacent to the target, so picking the center of the densest cluster maximizes hits. Note: this prioritizes AoE value over finishing a low-HP target — acceptable for general use.

**Recast guards (shouts / charge-based enchantments)**
- CanUse_DodgeThis, CanUse_IAmTheStrongest: block recast while the effect is already active (both are charge-based, not duration-based — recasting early wastes the skill).
- CanUse_SandShards: same guard added; Sand Shards is charge-based (1–5 hits) and recasting while active would stack incorrectly.

**Extend Enchantments → Vow of Strength sequencing**
- CanUse_VowOfStrength: removed a side-effect hack that was casting Extend from inside CanUse. Now returns False if Extend is in the bar but not yet active, letting the skill loop reach Extend first (slot-order dependency).
- CanUse_ExtendEnchantments: avoids spamming by blocking recast while already active. If VoS is also in the bar, additionally skips when VoS is currently active (Extend is only useful just before casting VoS). Builds without VoS are unaffected.