### PR TITLE
Basic Targeting for attacks that returned 0/Updated spells/Hex

### DIFF
--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Attack.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Attack.au3
@@ -34,7 +34,7 @@ Func BestTarget_Hamstring($a_f_AggroRange)
 	; Sword Attack. If this attack hits, your target is Crippled for 3...13...15 seconds, slowing his movement.
 	; Concise description
 	; Sword Attack. Inflicts Crippled condition (3...13...15 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 321 - $GC_I_SKILL_ID_WILD_BLOW
@@ -48,7 +48,7 @@ Func BestTarget_WildBlow($a_f_AggroRange)
 	; Melee Attack. Lose all adrenaline. If it hits, this attack will result in a critical hit and any stance being used by your target ends. This attack cannot be blocked.
 	; Concise description
 	; Melee Attack. Always a critical hit. Removes a stance. Unblockable. Lose all adrenaline.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 322 - $GC_I_SKILL_ID_POWER_ATTACK
@@ -76,7 +76,7 @@ Func BestTarget_DesperationBlow($a_f_AggroRange)
 	; Melee Attack. If this attack hits, you strike for +10...34...40 damage, and your target suffers from one of the following conditions: Deep Wound (for 20 seconds), Weakness (for 20 seconds), Bleeding (for 25 seconds), or Crippled (for 15 seconds). After making a Desperation Blow, you are knocked down.
 	; Concise description
 	; Melee Attack. Deals +10...34...40 damage. Inflicts one of the following random conditions: Deep Wound (20 seconds), Weakness (20 seconds), Bleeding (25 seconds), or Crippled (15 seconds). You are knocked-down.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 324 - $GC_I_SKILL_ID_THRILL_OF_VICTORY
@@ -90,7 +90,7 @@ Func BestTarget_ThrillOfVictory($a_f_AggroRange)
 	; Melee Attack. If this blow hits, you deal +20...36...40 damage. If you have more Health than target foe, you gain 1...2...2 strike[s] of adrenaline.
 	; Concise description
 	; Melee Attack. Deals +20...36...40 damage. If you have more Health than your target, you gain 1...2...2 adrenaline.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 325 - $GC_I_SKILL_ID_DISTRACTING_BLOW
@@ -104,7 +104,7 @@ Func BestTarget_DistractingBlow($a_f_AggroRange)
 	; This article is about the Core skill. For the temporarily available Bonus Mission Pack skill, see Distracting Blow (Turai Ossa).
 	; Concise description
 	; #808080;">Hits for no damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 326 - $GC_I_SKILL_ID_PROTECTORS_STRIKE
@@ -114,7 +114,11 @@ Func CanUse_ProtectorsStrike()
 EndFunc
 
 Func BestTarget_ProtectorsStrike($a_f_AggroRange)
-	Return 0
+	; Description
+	; Sword Attack. If this attack hits, you strike for +10...34...40 damage and gain +10...34...40 armor for 10 seconds.
+	; Concise description
+	; Sword Attack. Deals +10...34...40 damage. Gain +10...34...40 armor (10 seconds).
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 327 - $GC_I_SKILL_ID_GRIFFONS_SWEEP
@@ -124,7 +128,11 @@ Func CanUse_GriffonsSweep()
 EndFunc
 
 Func BestTarget_GriffonsSweep($a_f_AggroRange)
-	Return 0
+	; Description
+	; Sword Attack. If this attack hits, you strike for +1...16...20 damage and your target is Crippled for 3...13...15 seconds.
+	; Concise description
+	; Sword Attack. Deals +1...16...20 damage. Inflicts Crippled condition (3...13...15 seconds).
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 328 - $GC_I_SKILL_ID_PURE_STRIKE
@@ -138,7 +146,7 @@ Func BestTarget_PureStrike($a_f_AggroRange)
 	; Sword Attack. If Pure Strike hits, you strike for +1...24...30 damage. If you are not using a stance, Pure Strike cannot be blocked.
 	; Concise description
 	; Sword Attack. Deals +1...24...30 damage. Unblockable unless you are in a stance.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 329 - $GC_I_SKILL_ID_SKULL_CRACK
@@ -152,7 +160,7 @@ Func BestTarget_SkullCrack($a_f_AggroRange)
 	; Elite Melee Attack. If it hits, this attack interrupts the target's current action. If that foe was casting a spell, that foe is Dazed for 10 seconds.
 	; Concise description
 	; Elite Melee Attack. Interrupts an action. Inflicts Dazed condition (10 seconds) if target is casting a spell.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 330 - $GC_I_SKILL_ID_CYCLONE_AXE
@@ -191,7 +199,11 @@ Func CanUse_BullsStrike()
 EndFunc
 
 Func BestTarget_BullsStrike($a_f_AggroRange)
-	Return 0
+	; Description
+	; Sword Attack. If this attack hits, you strike for +10...34...40 damage and your target is knocked down.
+	; Concise description
+	; Sword Attack. Deals +10...34...40 damage. Causes knock-down.
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 334 - $GC_I_SKILL_ID_AXE_RAKE
@@ -205,7 +217,9 @@ Func BestTarget_AxeRake($a_f_AggroRange)
 	; Axe Attack. If this attack hits a foe suffering from a Deep Wound, you strike for +1...8...10 damage, and that foe becomes Crippled for 15 seconds.
 	; Concise description
 	; Axe Attack. Deals +1...8...10 damage and inflicts Crippled condition (15 seconds) if target foe has a Deep Wound.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsDeepWounded")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 335 - $GC_I_SKILL_ID_CLEAVE
@@ -219,7 +233,7 @@ Func BestTarget_Cleave($a_f_AggroRange)
 	; Elite Axe Attack. If this attack hits, you strike for +10...26...30 damage.
 	; Concise description
 	; Elite Axe Attack. Deals +10...26...30 damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 336 - $GC_I_SKILL_ID_EXECUTIONERS_STRIKE
@@ -247,7 +261,7 @@ Func BestTarget_Dismember($a_f_AggroRange)
 	; Axe Attack. If it hits, this axe blow will inflict a Deep Wound on the target foe, lowering that foe's maximum Health by 20% for 5...17...20 seconds.
 	; Concise description
 	; Axe Attack. Inflicts Deep Wound condition (5...17...20 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 338 - $GC_I_SKILL_ID_EVISCERATE
@@ -261,7 +275,7 @@ Func BestTarget_Eviscerate($a_f_AggroRange)
 	; Elite Axe Attack. If Eviscerate hits, you strike for +1...25...31 damage and inflict a Deep Wound, lowering your target's maximum Health by 20% for 5...17...20 seconds.
 	; Concise description
 	; Elite Axe Attack. Deals +1...25...31 damage. Inflicts Deep Wound condition (5...17...20 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 339 - $GC_I_SKILL_ID_PENETRATING_BLOW
@@ -275,7 +289,7 @@ Func BestTarget_PenetratingBlow($a_f_AggroRange)
 	; Axe Attack. If this attack hits, you strike for +5...17...20 damage. This axe attack has 20% armor penetration.
 	; Concise description
 	; Axe Attack. Deals +5...17...20 damage. 20% armor penetration.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 340 - $GC_I_SKILL_ID_DISRUPTING_CHOP
@@ -289,7 +303,7 @@ Func BestTarget_DisruptingChop($a_f_AggroRange)
 	; Axe Attack. If it hits, this attack interrupts the target's current action. If that action was a skill, that skill is disabled for an additional 20 seconds.
 	; Concise description
 	; Axe Attack. Interrupts an action. Interruption effect: interrupted skill is disabled for +20 seconds.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 341 - $GC_I_SKILL_ID_SWIFT_CHOP
@@ -303,7 +317,7 @@ Func BestTarget_SwiftChop($a_f_AggroRange)
 	; Axe Attack. If this attack hits, you strike for +1...16...20 damage. If Swift Chop is blocked, target foe takes 1...16...20 damage and suffers a Deep Wound for 20 seconds.
 	; Concise description
 	; Axe Attack. Deals +1...16...20 damage. Deals 1...16...20 damage and inflicts Deep Wound condition (20 seconds) if blocked.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 342 - $GC_I_SKILL_ID_AXE_TWIST
@@ -317,7 +331,9 @@ Func BestTarget_AxeTwist($a_f_AggroRange)
 	; Axe Attack. If this attack hits a foe suffering from a Deep Wound, you strike for 1...16...20 more damage and that foe suffers from Weakness for 20 seconds.
 	; Concise description
 	; Axe Attack. Deals +1...16...20 damage and inflicts Weakness condition (20 seconds) if target foe has a Deep Wound.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsDeepWounded")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 350 - $GC_I_SKILL_ID_BELLY_SMASH
@@ -331,7 +347,9 @@ Func BestTarget_BellySmash($a_f_AggroRange)
 	; Hammer Attack. If this attack strikes a foe who is knocked down, the resulting dust cloud will blind adjacent foes for 3...6...7 seconds.
 	; Concise description
 	; Hammer Attack. Inflicts Blindness condition to adjacent foes (3...6...7 seconds) if target foe is knocked down.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsKnockedDown")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 351 - $GC_I_SKILL_ID_MIGHTY_BLOW
@@ -345,7 +363,7 @@ Func BestTarget_MightyBlow($a_f_AggroRange)
 	; Hammer Attack. If this attack hits, you strike for +10...34...40 damage.
 	; Concise description
 	; Hammer Attack. Deals +10...34...40 damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 352 - $GC_I_SKILL_ID_CRUSHING_BLOW
@@ -359,7 +377,9 @@ Func BestTarget_CrushingBlow($a_f_AggroRange)
 	; Hammer Attack. If this attack hits, you strike for +1...16...20 damage. If you hit a knocked-down foe you inflict a Deep Wound, lowering your target's maximum Health by 20% for 5...17...20 seconds.
 	; Concise description
 	; Hammer Attack. Deals +1...16...20 damage. Inflicts Deep Wound condition if target foe is knocked-down (5...17...20 seconds).
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsKnockedDown")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 353 - $GC_I_SKILL_ID_CRUDE_SWING
@@ -373,7 +393,7 @@ Func BestTarget_CrudeSwing($a_f_AggroRange)
 	; Hammer Attack. Attack all adjacent foes. Each foe you hit is struck for +1...16...20 damage.
 	; Concise description
 	; Hammer Attack. Attack all adjacent foes for +1...16...20 damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 354 - $GC_I_SKILL_ID_EARTH_SHAKER
@@ -387,7 +407,7 @@ Func BestTarget_EarthShaker($a_f_AggroRange)
 	; Elite Hammer Attack. Target foe and all adjacent foes are knocked down. (50% failure chance with Hammer Mastery 4 or less.)
 	; Concise description
 	; Elite Hammer Attack. Knocks down target and adjacent foes. 50% failure chance unless Hammer Mastery is 5 or more.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 355 - $GC_I_SKILL_ID_DEVASTATING_HAMMER
@@ -401,7 +421,7 @@ Func BestTarget_DevastatingHammer($a_f_AggroRange)
 	; Elite Hammer Attack. If Devastating Hammer hits, your target is knocked down and suffers from Weakness for 5...17...20 seconds.
 	; Concise description
 	; Elite Hammer Attack. Causes knock-down. Inflicts Weakness condition (5...17...20 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 356 - $GC_I_SKILL_ID_IRRESISTIBLE_BLOW
@@ -415,7 +435,7 @@ Func BestTarget_IrresistibleBlow($a_f_AggroRange)
 	; Hammer Attack. If this attack hits, you strike for +5...17...20 damage. If Irresistible Blow is blocked, your target is knocked down and takes 5...17...20 damage.
 	; Concise description
 	; Hammer Attack. Deals +5...17...20 damage. Deals 5...17...20 damage and causes knock-down if blocked.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 357 - $GC_I_SKILL_ID_COUNTER_BLOW
@@ -429,7 +449,9 @@ Func BestTarget_CounterBlow($a_f_AggroRange)
 	; Hammer Attack. If this attack hits an attacking foe, that foe is knocked down.
 	; Concise description
 	; Hammer Attack. Causes knock-down if target foe is attacking.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 358 - $GC_I_SKILL_ID_BACKBREAKER
@@ -443,7 +465,7 @@ Func BestTarget_Backbreaker($a_f_AggroRange)
 	; Elite Hammer Attack. If Backbreaker hits, you strike for +1...16...20 damage and your target is knocked down. If you have 8 Strength or higher, this knockdown lasts 4 seconds.
 	; Concise description
 	; Elite Hammer Attack. Deals +1...16...20 damage. Causes knockdown. Knockdown lasts 4 seconds with Strength 8 or higher.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 359 - $GC_I_SKILL_ID_HEAVY_BLOW
@@ -457,7 +479,9 @@ Func BestTarget_HeavyBlow($a_f_AggroRange)
 	; Hammer Attack. Lose all adrenaline. If this attack hits a foe suffering from Weakness, that foe is knocked down and you strike for +1...24...30 damage.
 	; Concise description
 	; Hammer Attack. Deals +1...24...30 damage and causes knock-down if target foe is Weakened. Lose all adrenaline.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsWeakened")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 360 - $GC_I_SKILL_ID_STAGGERING_BLOW
@@ -471,7 +495,7 @@ Func BestTarget_StaggeringBlow($a_f_AggroRange)
 	; Hammer Attack. If this hammer blow hits, your target will suffer from Weakness for 5...17...20 seconds.
 	; Concise description
 	; Hammer Attack. Inflicts Weakness condition (5...17...20 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 382 - $GC_I_SKILL_ID_SEVER_ARTERY
@@ -499,7 +523,7 @@ Func BestTarget_GalrathSlash($a_f_AggroRange)
 	; Sword Attack. This attack strikes for +1...32...40 damage if it hits.
 	; Concise description
 	; Sword Attack. Deals +1...32...40 damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 384 - $GC_I_SKILL_ID_GASH
@@ -527,7 +551,7 @@ Func BestTarget_FinalThrust($a_f_AggroRange)
 	; Sword Attack. Lose all adrenaline. If Final Thrust hits, you deal 1...32...40 more damage. This damage is doubled if your target was below 50% Health.
 	; Concise description
 	; Sword Attack. Deals +1...32...40 damage. Deals +1...32...40 more damage if target foe is below 50% Health. Lose all adrenaline.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 386 - $GC_I_SKILL_ID_SEEKING_BLADE
@@ -541,7 +565,7 @@ Func BestTarget_SeekingBlade($a_f_AggroRange)
 	; Sword Attack. If this attack hits you strike for +1...16...20 damage. If Seeking Blade is blocked, your target begins Bleeding for 25 seconds and takes 1...16...20 damage.
 	; Concise description
 	; Sword Attack. Deals +1...16...20 damage. Deals 1...16...20 damage and inflicts Bleeding condition (25 seconds) if blocked.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 390 - $GC_I_SKILL_ID_SAVAGE_SLASH
@@ -555,7 +579,7 @@ Func BestTarget_SavageSlash($a_f_AggroRange)
 	; Sword Attack. If this attack hits, it interrupts target foe's action. If that action was a spell, you deal 1...32...40 extra damage.
 	; Concise description
 	; Sword Attack. Interrupts an action. Interruption effect: deals +1...32...40 damage if action was a spell.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 391 - $GC_I_SKILL_ID_HUNTERS_SHOT
@@ -565,7 +589,11 @@ Func CanUse_HuntersShot()
 EndFunc
 
 Func BestTarget_HuntersShot($a_f_AggroRange)
-	Return 0
+	; Description
+	; Bow Attack. If this attack hits, you strike for +1...16...20 damage.
+	; Concise description
+	; Bow Attack. Deals +1...16...20 damage.
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 392 - $GC_I_SKILL_ID_PIN_DOWN
@@ -579,7 +607,7 @@ Func BestTarget_PinDown($a_f_AggroRange)
 	; Bow Attack. If Pin Down hits, your target is Crippled for 3...13...15 seconds.
 	; Concise description
 	; Bow Attack. Inflicts Crippled condition (3...13...15 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 393 - $GC_I_SKILL_ID_CRIPPLING_SHOT
@@ -593,7 +621,7 @@ Func BestTarget_CripplingShot($a_f_AggroRange)
 	; Elite Bow Attack. If Crippling Shot hits, your target becomes Crippled for 1...9...11 second[s]. This attack cannot be blocked.
 	; Concise description
 	; Elite Bow Attack. Unblockable. Inflicts Crippled condition (1...9...11 second[s]).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 394 - $GC_I_SKILL_ID_POWER_SHOT
@@ -621,7 +649,7 @@ Func BestTarget_Barrage($a_f_AggroRange)
 	; Elite Bow Attack. All your preparations are removed. Shoot arrows at target foe and up to 5 foes adjacent to your target. These arrows strike for +5...17...20 damage if they hit.
 	; Concise description
 	; Elite Bow Attack. Deals +5...17...20 damage. Hits 5 foes adjacent to your target. All your preparations are removed.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 396 - $GC_I_SKILL_ID_DUAL_SHOT
@@ -649,7 +677,7 @@ Func BestTarget_QuickShot($a_f_AggroRange)
 	; Elite Bow Attack. Shoot an arrow that moves twice as fast.
 	; Concise description
 	; Elite Bow Attack. You shoot an arrow that moves twice as fast.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 398 - $GC_I_SKILL_ID_PENETRATING_ATTACK
@@ -663,7 +691,7 @@ Func BestTarget_PenetratingAttack($a_f_AggroRange)
 	; Bow Attack. If Penetrating Attack hits, you strike for +5...21...25 damage and this attack has 10% armor penetration.
 	; Concise description
 	; Bow Attack. Deals +5...21...25 damage. 10% armor penetration.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 399 - $GC_I_SKILL_ID_DISTRACTING_SHOT
@@ -691,7 +719,7 @@ Func BestTarget_PrecisionShot($a_f_AggroRange)
 	; Bow Attack. If Precision Shot hits, you strike for +3...9...10 damage. Precision Shot cannot be blocked. This action is easily interrupted.
 	; Concise description
 	; Bow Attack. Deals +3...9...10 damage. Unblockable. Easily Interrupted.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 401 - $GC_I_SKILL_ID_SPLINTER_SHOT_MONSTER_SKILL
@@ -706,7 +734,7 @@ Func BestTarget_DeterminedShot($a_f_AggroRange)
 	; Bow Attack. If Determined Shot hits, you strike for +5...17...20 damage. If Determined Shot fails to hit, all of your attack skills are recharged.
 	; Concise description
 	; Bow Attack. Deals +5...17...20 damage. Recharges your attack skills if it fails to hit.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 403 - $GC_I_SKILL_ID_CALLED_SHOT
@@ -720,7 +748,7 @@ Func BestTarget_CalledShot($a_f_AggroRange)
 	; Bow Attack. Shoot an arrow that moves 3 times faster and cannot be blocked.
 	; Concise description
 	; Bow Attack. You shoot an arrow that moves 3 times faster. Unblockable.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 404 - $GC_I_SKILL_ID_POISON_ARROW
@@ -734,7 +762,7 @@ Func BestTarget_PoisonArrow($a_f_AggroRange)
 	; This article is about the Ranger skill. For the monster skill, see Poison Arrow (flower).
 	; Concise description
 	; green; font-weight: bold;">5...17...20
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 405 - $GC_I_SKILL_ID_OATH_SHOT
@@ -748,7 +776,7 @@ Func BestTarget_OathShot($a_f_AggroRange)
 	; Elite Bow Attack. If Oath Shot hits, all of your skills except Oath Shot are recharged. If it misses, all of your skills are disabled for 10...5...4 seconds. (50% miss chance with Expertise 7 or less.)
 	; Concise description
 	; Elite Bow Attack. Recharges all skills except Oath Shot if it hits. Disables all skills if it misses (10...5...4 seconds). 50% miss chance unless Expertise 8 or higher.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 406 - $GC_I_SKILL_ID_DEBILITATING_SHOT
@@ -762,7 +790,7 @@ Func BestTarget_DebilitatingShot($a_f_AggroRange)
 	; Bow Attack. If Debilitating Shot hits, your target loses 1...8...10 Energy.
 	; Concise description
 	; Bow Attack. Causes 1...8...10 Energy loss.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 407 - $GC_I_SKILL_ID_POINT_BLANK_SHOT
@@ -792,7 +820,7 @@ Func BestTarget_ConcussionShot($a_f_AggroRange)
 	; Bow Attack. If Concussion Shot hits while target foe is casting a spell, the spell is interrupted and your target is Dazed for 5...17...20 seconds. This attack deals only 1...13...16 damage.
 	; Concise description
 	; Bow Attack. Interrupts a spell. Interruption effect: inflicts Dazed condition (5...17...20 seconds). Hits for only 1...13...16 damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 409 - $GC_I_SKILL_ID_PUNISHING_SHOT
@@ -806,7 +834,7 @@ Func BestTarget_PunishingShot($a_f_AggroRange)
 	; Elite Bow Attack. If Punishing Shot hits, you strike for +10...18...20 damage and your target is interrupted.
 	; Concise description
 	; Elite Bow Attack. Deals +10...18...20 damage. Interrupts an action.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 426 - $GC_I_SKILL_ID_SAVAGE_SHOT
@@ -834,7 +862,7 @@ Func BestTarget_IncendiaryArrows($a_f_AggroRange)
 	; Elite Bow Attack. Shoot arrows at target foe and up to 2 foes near your target. Those foes are set on fire for 1...3...3 second[s].
 	; Concise description
 	; Elite Bow Attack. Hits 2 foes near your target and inflicts burning (1...3...3 second[s]).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 501 - $GC_I_SKILL_ID_SIEGE_ATTACK4
@@ -858,7 +886,7 @@ Func BestTarget_BrutalMauling($a_f_AggroRange)
 	; Attack. Brutal Mauling
 	; Concise description
 	; Attack. Brutal Mauling
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 512 - $GC_I_SKILL_ID_CRIPPLING_ATTACK
@@ -872,7 +900,7 @@ Func BestTarget_CripplingAttack($a_f_AggroRange)
 	; Attack. (monster only)
 	; Concise description
 	; Attack. (monster only)
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 524 - $GC_I_SKILL_ID_DOZEN_SHOT
@@ -886,7 +914,7 @@ Func BestTarget_DozenShot($a_f_AggroRange)
 	; Monster skill
 	; Concise description
 	; 1em; margin-bottom:1em; clear:both;" />
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 530 - $GC_I_SKILL_ID_GIANT_STOMP
@@ -924,7 +952,7 @@ Func BestTarget_HungerOfTheLich($a_f_AggroRange)
 	; Attack. (monster only) If this attack hits target foe it removes one enchantment. If an enchantment is removed you gain 100 Health and 5 Energy.
 	; Concise description
 	; Attack. (monster only) Removes one enchantment. Removal effect: you gain 100 Health and 5 Energy.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 577 - $GC_I_SKILL_ID_SIEGE_ATTACK1
@@ -972,7 +1000,7 @@ Func BestTarget_TwistingFangs($a_f_AggroRange)
 	; Dual Attack. Must follow an off-hand attack. If it hits, Twisting Fangs strikes for +10...18...20 damage and struck foe suffers from Bleeding and Deep Wound for 5...17...20 seconds.
 	; Concise description
 	; Dual Attack. Deals +10...18...20 damage. Inflicts Bleeding and Deep Wound conditions (5...17...20 seconds). Must follow an off-hand attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsLastStrikeIsOffHand")
 EndFunc
 
 ; Skill ID: 777 - $GC_I_SKILL_ID_HORNS_OF_THE_OX
@@ -986,7 +1014,7 @@ Func BestTarget_HornsOfTheOx($a_f_AggroRange)
 	; Dual Attack. Must follow an off-hand attack. If it hits, Horns of the Ox strikes for +1...9...11 damage. If struck foe is not adjacent to any allies, that foe is knocked down.
 	; Concise description
 	; Dual Attack. Deals +1...9...11 damage. Causes knock-down if the target foe is not adjacent to any of its allies. Must follow an off-hand attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsLastStrikeIsOffHand")
 EndFunc
 
 ; Skill ID: 778 - $GC_I_SKILL_ID_FALLING_SPIDER
@@ -1000,7 +1028,9 @@ Func BestTarget_FallingSpider($a_f_AggroRange)
 	; Off-Hand Attack. Must strike a knocked-down foe. If it hits, Falling Spider strikes for +15...31...35 damage and target foe is Poisoned for 5...17...20 seconds.
 	; Concise description
 	; Off-Hand Attack. Deals +15...31...35 damage. Inflicts Poisoned condition (5...17...20 seconds). No effect unless target foe is knocked-down.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsKnockedDown")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 779 - $GC_I_SKILL_ID_BLACK_LOTUS_STRIKE
@@ -1046,7 +1076,9 @@ Func BestTarget_MoebiusStrike($a_f_AggroRange)
 	; Elite Off-Hand Attack. Must follow a Dual Attack. If it hits, Moebius Strike strikes for +10...30...35 damage. If you strike a foe whose Health is below 50%, all your other attack skills are recharged.
 	; Concise description
 	; Elite Off-Hand Attack. Deals +10...30...35 damage. Recharges all your other attack skills if target foe's Health is below 50%. Must follow a dual attack.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsLastStrikeIsDual")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsLastStrikeIsDual")
 EndFunc
 
 ; Skill ID: 782 - $GC_I_SKILL_ID_JAGGED_STRIKE
@@ -1076,7 +1108,7 @@ Func BestTarget_UnsuspectingStrike($a_f_AggroRange)
 	; Lead Attack. If this attack hits, you strike for +19...29...31 damage. If your target was above 90% Health you deal an additional 15...63...75 damage.
 	; Concise description
 	; Lead Attack. Deals +19...29...31 damage. Deals 15...63...75 more damage if target foe's Health is above 90%.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 849 - $GC_I_SKILL_ID_LACERATING_CHOP
@@ -1090,7 +1122,9 @@ Func BestTarget_LaceratingChop($a_f_AggroRange)
 	; Axe Attack. If Lacerating Chop hits, you deal +5...17...20 damage. If it strikes a knocked down foe your target suffers from Bleeding for 5...17...20 seconds.
 	; Concise description
 	; Axe Attack. Deals +5...17...20 damage. Inflicts Bleeding condition (5...17...20 seconds) if target foe is knocked-down.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsKnockedDown")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 850 - $GC_I_SKILL_ID_FIERCE_BLOW
@@ -1104,7 +1138,9 @@ Func BestTarget_FierceBlow($a_f_AggroRange)
 	; Hammer Attack. If Fierce Blow hits, you strike for +5...17...20 damage. If target foe was  suffering from Weakness, that foe also suffers from a Deep Wound for 1...7...8 second[s].
 	; Concise description
 	; Hammer Attack. Deals +5...17...20 damage. Inflicts Deep Wound (1...7...8 second[s]) if target foe is Weakened.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsWeakened")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 851 - $GC_I_SKILL_ID_SUN_AND_MOON_SLASH
@@ -1118,7 +1154,7 @@ Func BestTarget_SunAndMoonSlash($a_f_AggroRange)
 	; Sword Attack. Attack target foe twice. These attacks cannot be blocked.
 	; Concise description
 	; Sword Attack. You attack target foe twice. Unblockable.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 852 - $GC_I_SKILL_ID_SPLINTER_SHOT
@@ -1132,7 +1168,7 @@ Func BestTarget_SplinterShot($a_f_AggroRange)
 	; This article is about the player version of Splinter Shot. For the old version used by various monsters in EotN, see Splinter Shot (monster skill).
 	; Concise description
 	; green; font-weight: bold;">3...13...15
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 853 - $GC_I_SKILL_ID_MELANDRUS_SHOT
@@ -1142,7 +1178,11 @@ Func CanUse_MelandrusShot()
 EndFunc
 
 Func BestTarget_MelandrusShot($a_f_AggroRange)
-	Return 0
+	; Description
+	; Bow Attack. If this attack hits, you strike for +1...16...20 damage.
+	; Concise description
+	; Bow Attack. Deals +1...16...20 damage.
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 872 - $GC_I_SKILL_ID_SHADOWSONG_ATTACK
@@ -1152,7 +1192,11 @@ Func CanUse_ShadowsongAttack()
 EndFunc
 
 Func BestTarget_ShadowsongAttack($a_f_AggroRange)
-	Return 0
+	; Description
+	; Off-Hand Attack. If this attack hits, you strike for +1...16...20 damage.
+	; Concise description
+	; Off-Hand Attack. Deals +1...16...20 damage.
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 874 - $GC_I_SKILL_ID_CONSUMING_FLAMES
@@ -1166,7 +1210,7 @@ Func BestTarget_ConsumingFlames($a_f_AggroRange)
 	; This article is about the skill used by Flame Djinn.&#32;&#32;For the skill used by Arctic Nightmares during Flames of the Bear Spirit, see Consume Flames.
 	; Concise description
 	; Notes">edit
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 888 - $GC_I_SKILL_ID_WHIRLING_AXE
@@ -1180,7 +1224,7 @@ Func BestTarget_WhirlingAxe($a_f_AggroRange)
 	; Elite Axe Attack. If Whirling Axe hits, you strike for +5...17...20 damage and any stance being used by your target ends. This attack cannot be blocked.
 	; Concise description
 	; Elite Axe Attack. Deals +5...17...20 damage and removes a stance. Unblockable.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 889 - $GC_I_SKILL_ID_FORCEFUL_BLOW
@@ -1194,7 +1238,7 @@ Func BestTarget_ForcefulBlow($a_f_AggroRange)
 	; Elite Hammer Attack. If Forceful Blow hits, you strike for +10...26...30 damage and any stance being used by target foe ends. Target foe suffers from Weakness for 5...17...20 seconds. This attack cannot be blocked.
 	; Concise description
 	; Elite Hammer Attack. Deals +10...26...30 damage. Remove target foe's stance. Inflicts Weakness condition (5...17...20 seconds). Unblockable.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 892 - $GC_I_SKILL_ID_QUIVERING_BLADE
@@ -1208,7 +1252,7 @@ Func BestTarget_QuiveringBlade($a_f_AggroRange)
 	; This article is about the skill. For weapon with the same name, see Quivering Blade (weapon).
 	; Concise description
 	; green; font-weight: bold;">10...34...40
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 904 - $GC_I_SKILL_ID_FURIOUS_AXE
@@ -1222,7 +1266,7 @@ Func BestTarget_FuriousAxe($a_f_AggroRange)
 	; Axe Attack. If Furious Axe hits, you strike for +5...29...35 damage. If it is blocked you gain 3 strikes worth of adrenaline.
 	; Concise description
 	; Axe Attack. Deals +5...29...35 damage. Gives you 3 strikes of adrenaline if blocked.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 905 - $GC_I_SKILL_ID_AUSPICIOUS_BLOW
@@ -1236,7 +1280,7 @@ Func BestTarget_AuspiciousBlow($a_f_AggroRange)
 	; Hammer Attack. If Auspicious Blow hits, you strike for +5...17...20 damage and gain 3...7...8 Energy. If target foe is suffering from Weakness, this attack is unblockable.
 	; Concise description
 	; Hammer Attack. Deals +5...17...20 damage and you gain 3...7...8 Energy. Unblockable if target foe is Weakened.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 907 - $GC_I_SKILL_ID_DRAGON_SLASH
@@ -1250,7 +1294,7 @@ Func BestTarget_DragonSlash($a_f_AggroRange)
 	; This article is about the Factions skill. For the temporarily available Bonus Mission Pack skill, see Dragon Slash (Turai Ossa).
 	; Concise description
 	; green; font-weight: bold;">10...34...40
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 908 - $GC_I_SKILL_ID_MARAUDERS_SHOT
@@ -1260,7 +1304,8 @@ Func CanUse_MaraudersShot()
 EndFunc
 
 Func BestTarget_MaraudersShot($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 909 - $GC_I_SKILL_ID_FOCUSED_SHOT
@@ -1274,7 +1319,7 @@ Func BestTarget_FocusedShot($a_f_AggroRange)
 	; Bow Attack. If Focused Shot hits, you strike for +10...22...25 damage but all of your other attack skills are disabled for 5...3...3 seconds.
 	; Concise description
 	; Bow Attack. Deals +10...22...25 damage. Your other attack skills are disabled (5...3...3 seconds) if this attack hits.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 922 - $GC_I_SKILL_ID_DISSONANCE_ATTACK
@@ -1284,7 +1329,8 @@ Func CanUse_DissonanceAttack()
 EndFunc
 
 Func BestTarget_DissonanceAttack($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 924 - $GC_I_SKILL_ID_DISENCHANTMENT_ATTACK
@@ -1294,7 +1340,8 @@ Func CanUse_DisenchantmentAttack()
 EndFunc
 
 Func BestTarget_DisenchantmentAttack($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 948 - $GC_I_SKILL_ID_DESPERATE_STRIKE
@@ -1308,7 +1355,7 @@ Func BestTarget_DesperateStrike($a_f_AggroRange)
 	; Lead Attack. If you have less than 50...74...80% Health, you deal +15...51...60 damage.
 	; Concise description
 	; Lead Attack. Deals +15...51...60 damage if you have less than 50...74...80% Health.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 975 - $GC_I_SKILL_ID_EXHAUSTING_ASSAULT
@@ -1322,7 +1369,7 @@ Func BestTarget_ExhaustingAssault($a_f_AggroRange)
 	; Dual Attack. Must follow a lead attack. Target foe's action is interrupted. If that action was casting a spell, target foe suffers 10 Overcast.
 	; Concise description
 	; Dual Attack. Interrupts an action. Inflicts 10 Overcast if the interrupted action was a spell. Must follow a lead attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 976 - $GC_I_SKILL_ID_REPEATING_STRIKE
@@ -1336,7 +1383,7 @@ Func BestTarget_RepeatingStrike($a_f_AggroRange)
 	; Off-Hand Attack. Must follow an off-hand attack. If it hits, this attack strikes for +10...26...30 damage. If it misses, it takes an additional 15 seconds to recharge.
 	; Concise description
 	; Off-Hand Attack. Deals +10...26...30 damage. This skill has +15 second recharge time if it misses. Must follow an off-hand attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 986 - $GC_I_SKILL_ID_NINE_TAIL_STRIKE
@@ -1350,7 +1397,7 @@ Func BestTarget_NineTailStrike($a_f_AggroRange)
 	; Dual Attack. Must follow an off-hand attack. Nine Tail Strike cannot be blocked and strikes for +15...35...40 damage if it hits.
 	; Concise description
 	; Dual Attack. Deals +15...35...40 damage. Unblockable. Must follow an off-hand attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 988 - $GC_I_SKILL_ID_TEMPLE_STRIKE
@@ -1364,7 +1411,7 @@ Func BestTarget_TempleStrike($a_f_AggroRange)
 	; Elite Off-Hand Attack. Must follow a lead attack. If this attack hits, target foe is Dazed and Blinded for 1...8...10 seconds, and if target foe is casting a spell, that foe is interrupted.
 	; Concise description
 	; Elite Off-Hand Attack. Interrupts a spell. Inflicts Dazed and Blindness conditions (1...8...10 seconds). Must follow a lead attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 989 - $GC_I_SKILL_ID_GOLDEN_PHOENIX_STRIKE
@@ -1378,7 +1425,7 @@ Func BestTarget_GoldenPhoenixStrike($a_f_AggroRange)
 	; Off-Hand Attack. If you are not under the effects of an enchantment, this skill misses. If it hits, Golden Phoenix Strike deals +10...26...30 damage and all adjacent foes take 10...26...30 damage.
 	; Concise description
 	; Off-Hand Attack. Deals +10...26...30 damage to target and deals 10...26...30 damage to adjacent foes. Fails if you are not enchanted.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 992 - $GC_I_SKILL_ID_TRIPLE_CHOP
@@ -1392,7 +1439,7 @@ Func BestTarget_TripleChop($a_f_AggroRange)
 	; Elite Axe Attack. Attack target foe and adjacent foes. Each attack that hits deals +10...34...40 damage.
 	; Concise description
 	; Elite Axe Attack. Deals +10...34...40 damage. Also hits adjacent foes.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 993 - $GC_I_SKILL_ID_ENRAGED_SMASH
@@ -1406,7 +1453,7 @@ Func BestTarget_EnragedSmash($a_f_AggroRange)
 	; Elite Hammer Attack. If Enraged Smash hits, you gain 1...3...4 strike[s] of adrenaline. If you hit a moving foe, you strike for +10...34...40 damage, and target foe is knocked down.
 	; Concise description
 	; Elite Hammer Attack. Gives you 1...3...4 strike[s] of adrenaline if you hit. Deals +10...34...40 damage and causes knockdown if target foe was moving.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 994 - $GC_I_SKILL_ID_RENEWING_SMASH
@@ -1420,7 +1467,7 @@ Func BestTarget_RenewingSmash($a_f_AggroRange)
 	; Hammer Attack. If Renewing Smash hits, it deals +10...34...40 damage. If you hit a knocked-down foe, you gain 3 Energy and this attack recharges instantly.
 	; Concise description
 	; Hammer Attack. Deals +10...34...40 damage. You gain 3 Energy and this attack recharges instantly if target foe was knocked down.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 996 - $GC_I_SKILL_ID_STANDING_SLASH
@@ -1434,7 +1481,8 @@ Func BestTarget_StandingSlash($a_f_AggroRange)
 	; Sword Attack. If it hits, Standing Slash deals +5...17...20 damage plus an additional 5...17...20 damage if you are in a stance.
 	; Concise description
 	; Sword Attack. Deals +5...17...20 damage. Deals 5...17...20 more damage if you are in a stance.
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1019 - $GC_I_SKILL_ID_CRITICAL_STRIKE
@@ -1448,7 +1496,8 @@ Func BestTarget_CriticalStrike($a_f_AggroRange)
 	; Dual Attack. Must follow an off-hand attack. If it hits, this attack strikes for +10...26...30 damage, results in a critical hit, and you gain 1...3...3 Energy.
 	; Concise description
 	; Dual Attack. Deals +10...26...30 damage. Automatic critical hit. You gain 1...3...3 Energy. Must follow an off-hand attack.
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1020 - $GC_I_SKILL_ID_BLADES_OF_STEEL
@@ -1462,7 +1511,8 @@ Func BestTarget_BladesOfSteel($a_f_AggroRange)
 	; Dual Attack. Must follow an off-hand attack. If it hits, this attack strikes for +5...14...16 damage (maximum bonus 60) for each recharging dagger attack.
 	; Concise description
 	; Dual Attack. Deals +5...14...16 damage (maximum 60) for each recharging dagger attack. Must follow an off-hand attack.
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1021 - $GC_I_SKILL_ID_JUNGLE_STRIKE
@@ -1476,7 +1526,8 @@ Func BestTarget_JungleStrike($a_f_AggroRange)
 	; Off-Hand Attack. Must follow a lead attack. If it hits, this attack strikes for +10...22...25 damage. If it hits a foe that was Crippled, that foe and all adjacent foes take +1...25...31 damage.
 	; Concise description
 	; Off-Hand Attack. Deals +10...22...25 damage. Deals +1...25...31 damage to target and adjacent foes if target foe is Crippled. Must follow a lead attack.
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1022 - $GC_I_SKILL_ID_WILD_STRIKE
@@ -1504,7 +1555,8 @@ Func BestTarget_LeapingMantisSting($a_f_AggroRange)
 	; Lead Attack. If Mantis Sting hits, target foe takes +5...13...15 damage. If this attack strikes a moving foe, that foe is Crippled for 3...13...15 seconds.
 	; Concise description
 	; Lead Attack. Deals +5...13...15 damage. Inflicts Crippled condition (3...13...15 seconds) if target foe is moving.
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1024 - $GC_I_SKILL_ID_BLACK_MANTIS_THRUST
@@ -1536,7 +1588,7 @@ Func BestTarget_DisruptingStab($a_f_AggroRange)
 	; Lead Attack. If this attack hits, it interrupts target foe's action. If that action was a spell, it is disabled for 3...9...10 seconds.
 	; Concise description
 	; Lead Attack. Interrupts an action. If the interrupted action was a spell, it is disabled (3...9...10 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1026 - $GC_I_SKILL_ID_GOLDEN_LOTUS_STRIKE
@@ -1550,7 +1602,7 @@ Func BestTarget_GoldenLotusStrike($a_f_AggroRange)
 	; Lead Attack. If it hits, this attack strikes for +5...17...20 damage. If you are under the effects of an Enchantment, you gain 5...7...8 Energy.
 	; Concise description
 	; Lead Attack. Deals +5...17...20 damage. You gain 5...7...8 Energy if you are enchanted.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1133 - $GC_I_SKILL_ID_DRUNKEN_BLOW
@@ -1564,7 +1616,7 @@ Func BestTarget_DrunkenBlow($a_f_AggroRange)
 	; Melee Attack. If this attack hits, you strike for +10...34...40 damage and your target suffers from one of the following conditions: Deep Wound (for 20 seconds), Weakness (for 20 seconds), Bleeding (for 25 seconds), or Crippled (for 15 seconds). After making a Drunken Blow, you are knocked down.
 	; Concise description
 	; Melee Attack. Deals +10...34...40 damage. Inflicts one of the following random conditions: Deep Wound (20 seconds), Weakness (20 seconds), Bleeding (25 seconds), or Crippled (15 seconds). You are knocked-down.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1134 - $GC_I_SKILL_ID_LEVIATHANS_SWEEP
@@ -1574,7 +1626,8 @@ Func CanUse_LeviathansSweep()
 EndFunc
 
 Func BestTarget_LeviathansSweep($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1135 - $GC_I_SKILL_ID_JAIZHENJU_STRIKE
@@ -1588,7 +1641,7 @@ Func BestTarget_JaizhenjuStrike($a_f_AggroRange)
 	; Sword Attack. If Jaizhenju Strike hits, you strike for +1...24...30 damage. If you are not using a stance, Jaizhenju Strike cannot be blocked.
 	; Concise description
 	; Sword Attack. Deals +1...24...30 damage. Unblockable unless you are in a stance.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1136 - $GC_I_SKILL_ID_PENETRATING_CHOP
@@ -1602,7 +1655,7 @@ Func BestTarget_PenetratingChop($a_f_AggroRange)
 	; Axe Attack. If this attack hits, you strike for +5...17...20 damage. This axe attack has 20% armor penetration.
 	; Concise description
 	; Axe Attack. Deals +5...17...20 damage. 20% armor penetration.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1137 - $GC_I_SKILL_ID_YETI_SMASH
@@ -1616,7 +1669,7 @@ Func BestTarget_YetiSmash($a_f_AggroRange)
 	; Hammer Attack. Lose all adrenaline. Attack all adjacent foes. If this attack strikes a foe suffering from a condition, that foe is knocked down. (50% failure chance with Hammer Mastery 4 or less.)
 	; Concise description
 	; Hammer Attack. Attack all adjacent foes. Knocks down foes suffering from a condition. You lose all adrenaline. 50% failure chance unless Hammer Mastery is 5 or more.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1144 - $GC_I_SKILL_ID_SILVERWING_SLASH
@@ -1630,7 +1683,7 @@ Func BestTarget_SilverwingSlash($a_f_AggroRange)
 	; Sword Attack. This attack strikes for +1...32...40 damage if it hits.
 	; Concise description
 	; Sword Attack. Deals +1...32...40 damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1179 - $GC_I_SKILL_ID_DARK_CHAIN_LIGHTNING
@@ -1644,7 +1697,7 @@ Func BestTarget_DarkChainLightning($a_f_AggroRange)
 	; Attack. Target foe is struck for 300 lightning damage and is knocked down. Dark Chain Lightning then hits each nearest foe in succession, knocking down each foe and striking for 10% less damage each time.
 	; Concise description
 	; Attack. Deals 300 lightning damage and causes knock-down. Dark Chain Lightning then hits each nearest foe in succession, knocking-down each foe and doing 10% less damage each time.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1191 - $GC_I_SKILL_ID_SUNDERING_ATTACK
@@ -1658,7 +1711,7 @@ Func BestTarget_SunderingAttack($a_f_AggroRange)
 	; Bow Attack. If Sundering Attack hits, you strike for +5...21...25 damage and this attack has 10% armor penetration.
 	; Concise description
 	; Bow Attack. Deals +5...21...25 damage. 10% armor penetration.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1192 - $GC_I_SKILL_ID_ZOJUNS_SHOT
@@ -1668,7 +1721,8 @@ Func CanUse_ZojunsShot()
 EndFunc
 
 Func BestTarget_ZojunsShot($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1197 - $GC_I_SKILL_ID_NEEDLING_SHOT
@@ -1682,7 +1736,7 @@ Func BestTarget_NeedlingShot($a_f_AggroRange)
 	; Bow Attack. Needling Shot strikes for only 10...26...30 damage and moves faster than normal. If Needling Shot strikes a foe below 50% Health, Needling Shot recharges instantly. Your other attack skills are disabled for 2 seconds.
 	; Concise description
 	; Bow Attack. Fast-moving arrow. Deals 10...26...30 damage. Recharges instantly if target foe is below 50% Health. Your other attack skills are disabled (2 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1198 - $GC_I_SKILL_ID_BROAD_HEAD_ARROW
@@ -1696,7 +1750,7 @@ Func BestTarget_BroadHeadArrow($a_f_AggroRange)
 	; Elite Bow Attack. You shoot a broad head arrow that moves slower than normal. If it hits, target foe is Dazed for 5...17...20 seconds, and if target foe is casting a spell that spell is interrupted.
 	; Concise description
 	; Elite Bow Attack. Slow moving arrow. Interrupts a spell. Inflicts Dazed condition (5...17...20 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1248 - $GC_I_SKILL_ID_PAIN_ATTACK
@@ -1706,7 +1760,8 @@ Func CanUse_PainAttack()
 EndFunc
 
 Func BestTarget_PainAttack($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1254 - $GC_I_SKILL_ID_BLOODSONG_ATTACK
@@ -1716,7 +1771,8 @@ Func CanUse_BloodsongAttack()
 EndFunc
 
 Func BestTarget_BloodsongAttack($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1256 - $GC_I_SKILL_ID_WANDERLUST_ATTACK
@@ -1726,7 +1782,8 @@ Func CanUse_WanderlustAttack()
 EndFunc
 
 Func BestTarget_WanderlustAttack($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1309 - $GC_I_SKILL_ID_SUICIDE_ENERGY
@@ -1740,7 +1797,7 @@ Func BestTarget_SuicideEnergy($a_f_AggroRange)
 	; Attack. The next time you land a physical attack, you sacrifice all of your Health and target foe loses all Energy.
 	; Concise description
 	; Attack. The next time you land a physical attack, you sacrifice all of your Health and target foe loses all Energy.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1310 - $GC_I_SKILL_ID_SUICIDE_HEALTH
@@ -1754,7 +1811,7 @@ Func BestTarget_SuicideHealth($a_f_AggroRange)
 	; Attack. The next time you land a physical attack, you sacrifice all of your Health and target foe loses all Health.
 	; Concise description
 	; Attack. The next time you land a physical attack, you sacrifice all of your Health and target foe loses all Health.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1319 - ;  $GC_I_SKILL_ID_FINAL_THRUST
@@ -1779,7 +1836,7 @@ Func BestTarget_CriticalChop($a_f_AggroRange)
 	; Axe Attack. If this attack hits, you inflict +5...17...20 damage. If this attack results in a critical hit, target foe is interrupted.
 	; Concise description
 	; Axe Attack. Deals +5...17...20 damage. Interrupts an action if you land a critical hit.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1403 - $GC_I_SKILL_ID_AGONIZING_CHOP
@@ -1793,7 +1850,7 @@ Func BestTarget_AgonizingChop($a_f_AggroRange)
 	; Axe Attack. When this attack hits, you deal +5...17...20 damage. If target foe is suffering from a Deep Wound, you interrupt that foe's action.
 	; Concise description
 	; Axe Attack. Deals +5...17...20 damage. Interrupts an action if target foe has a Deep Wound.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1409 - $GC_I_SKILL_ID_MOKELE_SMASH
@@ -1807,7 +1864,7 @@ Func BestTarget_MokeleSmash($a_f_AggroRange)
 	; Hammer Attack. If this attack hits, you strike for +5...17...20 damage and gain 2 strikes of adrenaline.
 	; Concise description
 	; Hammer Attack. Deals +5...17...20 damage and you gain 2 strikes of adrenaline.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1410 - $GC_I_SKILL_ID_OVERBEARING_SMASH
@@ -1821,7 +1878,7 @@ Func BestTarget_OverbearingSmash($a_f_AggroRange)
 	; Hammer Attack. If this attack hits, you deal +1...16...20 damage. If target foe is knocked down, that foe is Dazed for 1...7...8 second[s].
 	; Concise description
 	; Hammer Attack. Deals +1...16...20 damage. If target foe is knocked down, they are Dazed (1...7...8 second[s]).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1415 - $GC_I_SKILL_ID_CRIPPLING_SLASH
@@ -1835,7 +1892,7 @@ Func BestTarget_CripplingSlash($a_f_AggroRange)
 	; Elite Sword Attack. If this attack hits, target foe is Crippled for 5...13...15 seconds and begins Bleeding for 10...22...25 seconds.
 	; Concise description
 	; Elite Sword Attack. Inflicts Crippled condition (5...13...15 seconds) and Bleeding condition (10...22...25 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1416 - $GC_I_SKILL_ID_BARBAROUS_SLICE
@@ -1849,7 +1906,7 @@ Func BestTarget_BarbarousSlice($a_f_AggroRange)
 	; Sword Attack. If this attack hits, you deal +5...25...30 damage. If you are currently not in a stance, you also inflict Bleeding for 5...13...15 seconds.
 	; Concise description
 	; Sword Attack. Deals +5...25...30 damage. Inflicts Bleeding condition (5...13...15 seconds) if you are not in a stance.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1419 - $GC_I_SKILL_ID_FEEDING_FRENZY_SKILL
@@ -1859,7 +1916,8 @@ Func CanUse_FeedingFrenzySkill()
 EndFunc
 
 Func BestTarget_FeedingFrenzySkill($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1420 - $GC_I_SKILL_ID_QUAKE_OF_AHDASHIM
@@ -1883,7 +1941,8 @@ Func CanUse_HungersBite()
 EndFunc
 
 Func BestTarget_HungersBite($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1461 - $GC_I_SKILL_ID_EARTH_VORTEX
@@ -1897,7 +1956,7 @@ Func BestTarget_EarthVortex($a_f_AggroRange)
 	; Attack. For 30 seconds, all foes in this area are struck for 15 earth damage every second. Any foe using a skill when struck is knocked down.
 	; Concise description
 	; Attack. (30 seconds.) Deals 15 earth damage every second to all foes in the area. Any foe using a skill when struck is knocked-down.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1462 - $GC_I_SKILL_ID_FROST_VORTEX
@@ -1911,7 +1970,7 @@ Func BestTarget_FrostVortex($a_f_AggroRange)
 	; Attack. For 30 seconds, all foes in the area are struck for 50 cold damage every 3 seconds. Any foe moving when struck is slowed by 90% for 10 seconds.
 	; Concise description
 	; Attack. (30 seconds.) Deals 50 cold damage every 3 seconds to all foes in the area. Any foe moving when struck moves 90% slower (10 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1465 - $GC_I_SKILL_ID_PREPARED_SHOT
@@ -1925,7 +1984,7 @@ Func BestTarget_PreparedShot($a_f_AggroRange)
 	; Elite Bow Attack. If this attack hits, you strike for +10...22...25 damage. If you are under the effects of a preparation, you gain 1...7...9 Energy.
 	; Concise description
 	; Elite Bow Attack. Deals +10...22...25 damage. You gain 1...7...9 Energy if you have a preparation active.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1466 - $GC_I_SKILL_ID_BURNING_ARROW
@@ -1939,7 +1998,7 @@ Func BestTarget_BurningArrow($a_f_AggroRange)
 	; Elite Bow Attack. If this attack hits, you strike for +10...26...30 damage and cause Burning for 1...6...7 seconds.
 	; Concise description
 	; Elite Bow Attack. Deals +10...26...30 damage. Inflicts Burning condition (1...6...7 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1467 - $GC_I_SKILL_ID_ARCING_SHOT
@@ -1953,7 +2012,7 @@ Func BestTarget_ArcingShot($a_f_AggroRange)
 	; Bow Attack. If this arrow hits, it strikes for +10...22...25 damage. This arrow cannot be blocked, but it moves 50% slower.
 	; Concise description
 	; Bow Attack. Deals +10...22...25 damage. Unblockable. This arrow moves 50% slower.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1469 - $GC_I_SKILL_ID_CROSSFIRE
@@ -1967,7 +2026,7 @@ Func BestTarget_Crossfire($a_f_AggroRange)
 	; Bow Attack. If this attack hits target foe, it deals +5...17...20 damage. If that foe is near any of your allies, this attack cannot be blocked.
 	; Concise description
 	; Bow Attack. Deals +5...17...20 damage. Unblockable if target foe is near any of your allies.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1483 - $GC_I_SKILL_ID_BANISHING_STRIKE
@@ -1981,7 +2040,7 @@ Func BestTarget_BanishingStrike($a_f_AggroRange)
 	; Melee Attack. If it hits, this attack deals 10...50...60 holy damage. It deals double damage to summoned creatures.
 	; Concise description
 	; Melee Attack. Deals 10...50...60 holy damage. Deals double damage to summoned creatures.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1484 - $GC_I_SKILL_ID_MYSTIC_SWEEP
@@ -2052,7 +2111,7 @@ Func BestTarget_VictoriousSweep($a_f_AggroRange)
 	; Melee Attack. If this attack hits, you deal +5...21...25 damage. If target foe has less Health than you, you gain 30...70...80 Health.
 	; Concise description
 	; Melee Attack. Deals +5...21...25 damage. You gain 30...70...80 Health for each foe you hit that has less Health than you.
-	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1489 - $GC_I_SKILL_ID_IRRESISTIBLE_SWEEP
@@ -2096,7 +2155,7 @@ Func BestTarget_CripplingSweep($a_f_AggroRange)
 	; Scythe Attack. If this attack hits a foe, that foe is Crippled for 3...10...12 seconds. This skill deals +3...13...15 extra damage if that foe is moving.
 	; Concise description
 	; Scythe Attack. (3...10...12 seconds.) Inflicts Cripple [sic] condition. Deals +3...13...15 damage to moving foes.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1536 - $GC_I_SKILL_ID_WOUNDING_STRIKE
@@ -2110,7 +2169,7 @@ Func BestTarget_WoundingStrike($a_f_AggroRange)
 	; Elite Scythe Attack. If this attack hits, you do +5...17...20 damage, target foe suffers from Bleeding for 5...17...20 seconds, and you lose 1 Dervish enchantment. If an enchantment is removed, target foe also suffers from a Deep Wound for 5...17...20 seconds.
 	; Concise description
 	; Elite Scythe Attack. Deals +5...17...20 damage and inflicts Bleeding condition (5...17...20 seconds). Remove 1 Dervish enchantment. Removal Effect: inflicts Deep Wound condition (5...17...20 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1537 - $GC_I_SKILL_ID_WEARYING_STRIKE
@@ -2135,7 +2194,8 @@ Func CanUse_LyssasAssault()
 EndFunc
 
 Func BestTarget_LyssasAssault($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1539 - $GC_I_SKILL_ID_CHILLING_VICTORY
@@ -2177,7 +2237,7 @@ Func BestTarget_MightyThrow($a_f_AggroRange)
 	; Spear Attack. Your spear moves three times faster. If it hits, you deal +10...34...40 damage.
 	; Concise description
 	; Spear Attack. Deals +10...34...40 damage. This spear moves three times faster.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1548 - $GC_I_SKILL_ID_CRUEL_SPEAR
@@ -2201,7 +2261,8 @@ Func CanUse_HarriersToss()
 EndFunc
 
 Func BestTarget_HarriersToss($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1550 - $GC_I_SKILL_ID_UNBLOCKABLE_THROW
@@ -2215,7 +2276,7 @@ Func BestTarget_UnblockableThrow($a_f_AggroRange)
 	; Spear Attack. If this attack hits, you deal +10...34...40 damage. This attack cannot be blocked.
 	; Concise description
 	; Spear Attack. Deals +10...34...40 damage. Unblockable.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1551 - $GC_I_SKILL_ID_SPEAR_OF_LIGHTNING
@@ -2243,7 +2304,7 @@ Func BestTarget_WearyingSpear($a_f_AggroRange)
 	; Spear Attack. If this attack hits, you deal +10...34...40 damage. You are Weakened for 5 seconds.
 	; Concise description
 	; Spear Attack. Deals +10...34...40 damage. You are Weakened (5 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1600 - $GC_I_SKILL_ID_BARBED_SPEAR
@@ -2273,7 +2334,7 @@ Func BestTarget_ViciousAttack($a_f_AggroRange)
 	; Spear Attack. If this attack hits, you deal +5...17...20 damage. If you land a critical hit with this attack, target foe suffers from a Deep Wound for 5...13...15 seconds.
 	; Concise description
 	; Spear Attack. Deals +5...17...20 damage. Inflicts Deep Wound condition (5...13...15 seconds) with a critical hit.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1602 - $GC_I_SKILL_ID_STUNNING_STRIKE
@@ -2287,7 +2348,7 @@ Func BestTarget_StunningStrike($a_f_AggroRange)
 	; Elite Spear Attack. If this attack hits, you deal +5...25...30 damage. If it hits a foe suffering from a condition, that foe is also Dazed for 4...9...10 seconds.
 	; Concise description
 	; Elite Spear Attack. Deals +5...25...30 damage. Inflicts Dazed condition (4...9...10 seconds) if target has a condition.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1603 - $GC_I_SKILL_ID_MERCILESS_SPEAR
@@ -2303,7 +2364,7 @@ Func BestTarget_MercilessSpear($a_f_AggroRange)
 	; Spear Attack. Inflicts Deep Wound condition (5...17...20 seconds). No effect unless target has less than 50% Health.
 	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.5 Then Return $l_i_Target
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1604 - $GC_I_SKILL_ID_DISRUPTING_THROW
@@ -2317,7 +2378,7 @@ Func BestTarget_DisruptingThrow($a_f_AggroRange)
 	; Spear Attack. If this attack hits a foe suffering from a condition, that foe is interrupted.
 	; Concise description
 	; Spear Attack. Interrupts actions. No effect unless target has a condition.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1605 - $GC_I_SKILL_ID_WILD_THROW
@@ -2331,7 +2392,7 @@ Func BestTarget_WildThrow($a_f_AggroRange)
 	; Spear Attack. If this attack hits, it deals +5...17...20 damage, and any stance being used by your target ends. This attack cannot be blocked. All of your non-spear attack skills are disabled for 3 seconds.
 	; Concise description
 	; Spear Attack. Deals +5...17...20 damage. Unblockable. Ends target's stance.Disables [sic] your non-spear attack skills for 3 seconds.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1633 - $GC_I_SKILL_ID_MALICIOUS_STRIKE
@@ -2345,7 +2406,7 @@ Func BestTarget_MaliciousStrike($a_f_AggroRange)
 	; Melee Attack. If this attack hits a foe suffering from a condition, you deal +10...26...30 damage and this attack results in a critical hit.
 	; Concise description
 	; Melee Attack. If target foe has a condition, this attack deals +10...26...30 damage and is a critical hit.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1634 - $GC_I_SKILL_ID_SHATTERING_ASSAULT
@@ -2359,7 +2420,7 @@ Func BestTarget_ShatteringAssault($a_f_AggroRange)
 	; Elite Dual Attack. Must follow an off-hand attack. If it hits, you deal 5...41...50 damage and target foe loses one enchantment. This attack cannot be blocked.
 	; Concise description
 	; Elite Dual Attack. Deals 5...41...50 damage. Removes one enchantment. Unblockable. Must follow an off-hand attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1635 - $GC_I_SKILL_ID_GOLDEN_SKULL_STRIKE
@@ -2373,7 +2434,7 @@ Func BestTarget_GoldenSkullStrike($a_f_AggroRange)
 	; Elite Off-Hand Attack. If you are under the effects of an enchantment and this attack hits, target foe is Dazed 1...4...5 seconds.
 	; Concise description
 	; Elite Off-Hand Attack. Inflicts Dazed condition (1...4...5 seconds). No effect unless you are enchanted.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1636 - $GC_I_SKILL_ID_BLACK_SPIDER_STRIKE
@@ -2387,7 +2448,9 @@ Func BestTarget_BlackSpiderStrike($a_f_AggroRange)
 	; Off-Hand Attack. Must strike a hexed foe. If it hits, this attack strikes for +5...17...20 damage and target foe is Poisoned for 5...17...20 seconds.
 	; Concise description
 	; Off-Hand Attack. Deals +5...17...20 damage. Inflicts Poisoned condition (5...17...20 seconds). Must strike a hexed foe.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1637 - $GC_I_SKILL_ID_GOLDEN_FOX_STRIKE
@@ -2401,7 +2464,7 @@ Func BestTarget_GoldenFoxStrike($a_f_AggroRange)
 	; GFS redirects here. For other uses, see GFS (disambiguation).
 	; Concise description
 	; green; font-weight: bold;">10...26...30
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1670 - $GC_I_SKILL_ID_SIEGE_ATTACK_BOMBARDMENT
@@ -2425,7 +2488,9 @@ Func BestTarget_Counterattack($a_f_AggroRange)
 	; Melee Attack. If this attack hits, you strike for +5...29...35 damage. If you hit an attacking foe, you gain 2...5...6 Energy.
 	; Concise description
 	; Melee Attack. Deals +5...29...35 damage. You gain 2...5...6 Energy if target foe is attacking.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1694 - $GC_I_SKILL_ID_MAGEHUNTER_STRIKE
@@ -2439,7 +2504,9 @@ Func BestTarget_MagehunterStrike($a_f_AggroRange)
 	; Elite Melee Attack. If this attack hits, you strike for +5...17...20 damage. If your target is under the effects of an enchantment, this attack cannot be blocked.
 	; Concise description
 	; Elite Melee Attack. Deals +5...17...20 damage. Unblockable if target foe is enchanted.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1695 - $GC_I_SKILL_ID_SOLDIERS_STRIKE
@@ -2449,7 +2516,8 @@ Func CanUse_SoldiersStrike()
 EndFunc
 
 Func BestTarget_SoldiersStrike($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1696 - $GC_I_SKILL_ID_DECAPITATE
@@ -2463,7 +2531,7 @@ Func BestTarget_Decapitate($a_f_AggroRange)
 	; Elite Axe Attack. You lose all adrenaline and all Energy. If this attack hits, you deal +5...41...50 damage and cause a Deep Wound for 5...17...20 seconds. This attack always results in a critical hit.
 	; Concise description
 	; Elite Axe Attack. Deals +5...41...50 damage. Inflicts Deep Wound condition (5...17...20 seconds). Automatic critical hit. You lose all adrenaline and Energy.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1697 - $GC_I_SKILL_ID_MAGEHUNTERS_SMASH
@@ -2473,7 +2541,8 @@ Func CanUse_MagehuntersSmash()
 EndFunc
 
 Func BestTarget_MagehuntersSmash($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1702 - $GC_I_SKILL_ID_STEELFANG_SLASH
@@ -2487,7 +2556,9 @@ Func BestTarget_SteelfangSlash($a_f_AggroRange)
 	; Sword Attack. If this attack hits, you deal +1...25...31 damage. If you hit a foe that is knocked down, you gain 1...4...5 adrenaline.
 	; Concise description
 	; Sword Attack. Deals +1...25...31 damage. You gain 1...4...5 adrenaline if target foe is knocked down.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsKnockedDown")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1705 - $GC_I_SKILL_ID_EARTH_SHATTERING_BLOW
@@ -2501,7 +2572,7 @@ Func BestTarget_EarthShatteringBlow($a_f_AggroRange)
 	; Attack. All foes in the area of target take 100 blunt damage and are knocked down. Surrounding foes take 80 earth damage.
 	; Concise description
 	; Attack. Deals 100 blunt damage and causes knock-down to foes in the area of target. 80 earth damage to surrounding foes.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1719 - $GC_I_SKILL_ID_SCREAMING_SHOT
@@ -2515,7 +2586,7 @@ Func BestTarget_ScreamingShot($a_f_AggroRange)
 	; Bow Attack. If this attack hits, you deal +10...22...25 damage. If your target is within earshot, that foe begins Bleeding for 5...17...20 seconds.
 	; Concise description
 	; Bow Attack. Deals +10...22...25 damage. Inflicts Bleeding condition (5...17...20 seconds) if target foe is within earshot.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1720 - $GC_I_SKILL_ID_KEEN_ARROW
@@ -2529,7 +2600,7 @@ Func BestTarget_KeenArrow($a_f_AggroRange)
 	; Bow Attack. If this attack hits, you strike for +5...17...20 damage. If you land a critical hit, you deal an additional +5...21...25 damage.
 	; Concise description
 	; Bow Attack. Deals +5...17...20 damage. Deals +5...21...25 more damage if you land a critical hit.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1722 - $GC_I_SKILL_ID_FORKED_ARROW
@@ -2543,7 +2614,7 @@ Func BestTarget_ForkedArrow($a_f_AggroRange)
 	; Bow Attack. Shoot two arrows simultaneously at target foe. If you are under the effects of an enchantment or hex, you shoot only one arrow.
 	; Concise description
 	; Bow Attack. You shoot two arrows simultaneously. Shoot only one arrow if you are enchanted or hexed.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1726 - $GC_I_SKILL_ID_MAGEBANE_SHOT
@@ -2557,7 +2628,7 @@ Func BestTarget_MagebaneShot($a_f_AggroRange)
 	; Elite Bow Attack. If this attack hits, it interrupts target foe's action. If that action was a spell, it is disabled for an additional 10 seconds. This attack cannot be blocked.
 	; Concise description
 	; Elite Bow Attack. Interrupts an action. Interruption effect: an interrupted spell is disabled for +10 seconds. Unblockable.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1735 - $GC_I_SKILL_ID_GAZE_OF_FURY_ATTACK
@@ -2567,7 +2638,8 @@ Func CanUse_GazeOfFuryAttack()
 EndFunc
 
 Func BestTarget_GazeOfFuryAttack($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1746 - $GC_I_SKILL_ID_ANGUISH_ATTACK
@@ -2577,7 +2649,8 @@ Func CanUse_AnguishAttack()
 EndFunc
 
 Func BestTarget_AnguishAttack($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1753 - $GC_I_SKILL_ID_RENDING_SWEEP
@@ -2602,7 +2675,8 @@ Func CanUse_ReapersSweep()
 EndFunc
 
 Func BestTarget_ReapersSweep($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1783 - $GC_I_SKILL_ID_SLAYERS_SPEAR
@@ -2612,7 +2686,8 @@ Func CanUse_SlayersSpear()
 EndFunc
 
 Func BestTarget_SlayersSpear($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1784 - $GC_I_SKILL_ID_SWIFT_JAVELIN
@@ -2626,7 +2701,7 @@ Func BestTarget_SwiftJavelin($a_f_AggroRange)
 	; Spear Attack. If this attack hits, you deal +5...17...20 damage. If you are under the effects of an enchantment, this spear flies twice as fast and cannot be blocked.
 	; Concise description
 	; Spear Attack. Deals +5...17...20 damage. This spear moves twice as fast and is unblockable if you are enchanted.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1895 - $GC_I_SKILL_ID_WILD_SMASH
@@ -2640,7 +2715,7 @@ Func BestTarget_WildSmash($a_f_AggroRange)
 	; Attack. Target foe is knocked down. Any stances currently in use by target foe end and are disabled for 5 seconds. This attack cannot be blocked.
 	; Concise description
 	; Attack. Causes knock-down. Ends a stance and disables it (5 seconds). Unblockable.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1897 - $GC_I_SKILL_ID_JADOTHS_STORM_OF_JUDGMENT
@@ -2650,7 +2725,8 @@ Func CanUse_JadothsStormOfJudgment()
 EndFunc
 
 Func BestTarget_JadothsStormOfJudgment($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1935 - $GC_I_SKILL_ID_TORTUROUS_EMBERS
@@ -2664,7 +2740,7 @@ Func BestTarget_TorturousEmbers($a_f_AggroRange)
 	; Monster skill
 	; Concise description
 	; "en","wgPageContentModel":"wikitext","wgRelevantPageName":"Torturous_Embers","wgRelevantArticleId":282757,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgMFDisplayWikibaseDescriptions":{"search":false,"nearby":false,"watchlist":false,"tagline":false},"wgPopupsFlags":4,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true}; RLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready","user.options":"loading","skins.monobook.styles":"ready"};RLPAGEMODULES=["site","mediawiki.page.ready","skins.monobook.scripts","mmv.head","mmv.bootstrap.autostart","ext.popups"];
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1953 - $GC_I_SKILL_ID_TRIPLE_SHOT_LUXON
@@ -2674,7 +2750,8 @@ Func CanUse_TripleShotLuxon()
 EndFunc
 
 Func BestTarget_TripleShotLuxon($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1957 - $GC_I_SKILL_ID_SPEAR_OF_FURY_LUXON
@@ -2684,7 +2761,8 @@ Func CanUse_SpearOfFuryLuxon()
 EndFunc
 
 Func BestTarget_SpearOfFuryLuxon($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1986 - $GC_I_SKILL_ID_VAMPIRIC_ASSAULT
@@ -2698,7 +2776,7 @@ Func BestTarget_VampiricAssault($a_f_AggroRange)
 	; Dual Attack. Must follow an off-hand attack. If this attack hits, you steal 10...34...40 Health.
 	; Concise description
 	; Dual Attack. Steals 10...34...40 Health if this attack hits. Must follow an off-hand attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1987 - $GC_I_SKILL_ID_LOTUS_STRIKE
@@ -2712,7 +2790,7 @@ Func BestTarget_LotusStrike($a_f_AggroRange)
 	; Off-Hand Attack. Must follow a lead attack. If it hits, this attack strikes for +10...22...25 damage and you gain 5...17...20 Energy.
 	; Concise description
 	; Off-Hand Attack. Deals +10...22...25 damage; you gain 5...17...20 Energy. Must follow a lead attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1988 - $GC_I_SKILL_ID_GOLDEN_FANG_STRIKE
@@ -2726,7 +2804,7 @@ Func BestTarget_GoldenFangStrike($a_f_AggroRange)
 	; Off-Hand Attack. Must follow a lead attack. If you are under the effects of an enchantment and this attack hits, target foe suffers from a Deep Wound for 5...17...20 seconds.
 	; Concise description
 	; Off-Hand Attack. Inflicts Deep Wound condition (5...17...20 seconds) if you are enchanted. Must follow a lead attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1990 - $GC_I_SKILL_ID_FALLING_LOTUS_STRIKE
@@ -2740,7 +2818,7 @@ Func BestTarget_FallingLotusStrike($a_f_AggroRange)
 	; Off-Hand Attack. Must strike a knocked-down foe. If it hits, you strike for +15...31...35 damage and gain 1...10...12 Energy.
 	; Concise description
 	; Off-Hand Attack. Deals +15...31...35 damage; you gain 1...10...12 Energy. No effect unless target foe is knocked-down.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2008 - $GC_I_SKILL_ID_PULVERIZING_SMASH
@@ -2754,7 +2832,7 @@ Func BestTarget_PulverizingSmash($a_f_AggroRange)
 	; Hammer Attack. If you hit a knocked-down foe, that foe suffers from Weakness and a Deep Wound for 5...17...20 seconds.
 	; Concise description
 	; Hammer Attack. Inflicts Weakness and Deep Wound conditions (5...17...20 seconds) if target foe is knocked-down.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2009 - $GC_I_SKILL_ID_KEEN_CHOP
@@ -2768,7 +2846,7 @@ Func BestTarget_KeenChop($a_f_AggroRange)
 	; Axe Attack. If it hits, this attack always results in a critical hit.
 	; Concise description
 	; Axe Attack. Always a critical hit.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2010 - $GC_I_SKILL_ID_KNEE_CUTTER
@@ -2782,7 +2860,7 @@ Func BestTarget_KneeCutter($a_f_AggroRange)
 	; Sword Attack. If this attack hits a Crippled foe, you gain 2...6...7 Energy and 1...3...3 strikes  of adrenaline.
 	; Concise description
 	; Sword Attack. You gain 2...6...7 Energy and 1...3...3 adrenaline if target foe is Crippled.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2012 - $GC_I_SKILL_ID_RADIANT_SCYTHE
@@ -2796,7 +2874,7 @@ Func BestTarget_RadiantScythe($a_f_AggroRange)
 	; Scythe Attack. This attack strikes for +1 damage for each point of Energy you currently have, maximum 5...25...30. You gain 1...6...7 Energy if this attack hits.
 	; Concise description
 	; Scythe Attack. Deals +1 damage (maximum 5...25...30) for each point of Energy you have. Gain 1...6...7 Energy.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2015 - $GC_I_SKILL_ID_FARMERS_SCYTHE
@@ -2806,7 +2884,8 @@ Func CanUse_FarmersScythe()
 EndFunc
 
 Func BestTarget_FarmersScythe($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2066 - $GC_I_SKILL_ID_DISARM
@@ -2820,7 +2899,7 @@ Func BestTarget_Disarm($a_f_AggroRange)
 	; Sword Attack. Interrupt target foe's action. If that action was an attack, all of that foe's attack skills are disabled for 0...2...3 second[s].
 	; Concise description
 	; Sword Attack. Interrupts target foe. Interruption effect: disables this foe's attack skills (0...2...3 second[s]) if that action was an attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2069 - $GC_I_SKILL_ID_SLOTH_HUNTERS_SHOT
@@ -2844,7 +2923,7 @@ Func BestTarget_AuraSlicer($a_f_AggroRange)
 	; Melee Attack. If this attack hits, you inflict Bleeding for 5...13...15 seconds. If you are enchanted, you also inflict Cracked Armor for 1...8...10 second[s].
 	; Concise description
 	; Melee Attack. (5...13...15 seconds.)Inflicts [sic] Bleeding condition. Also inflicts Cracked Armor (1...8...10 second[s]) if you are enchanted.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2071 - $GC_I_SKILL_ID_ZEALOUS_SWEEP
@@ -2858,7 +2937,7 @@ Func BestTarget_ZealousSweep($a_f_AggroRange)
 	; Scythe Attack. If this attack hits, you deal +5...17...20 damage. You gain 3 Energy and 1 adrenaline for each foe you hit.
 	; Concise description
 	; Scythe Attack. Deals +5...17...20 damage. You gain 3 Energy and 1 adrenaline for each foe you hit.
-	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2074 - $GC_I_SKILL_ID_CHEST_THUMPER
@@ -2872,7 +2951,7 @@ Func BestTarget_ChestThumper($a_f_AggroRange)
 	; Spear Attack. If this attack hits a foe with Cracked Armor, that foe suffers a Deep Wound for 5...17...20 seconds.
 	; Concise description
 	; Spear Attack. Inflicts Deep Wound condition (5...17...20 seconds) if target foe has Cracked Armor.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2096 - $GC_I_SKILL_ID_TRIPLE_SHOT_KURZICK
@@ -2882,7 +2961,8 @@ Func CanUse_TripleShotKurzick()
 EndFunc
 
 Func BestTarget_TripleShotKurzick($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2099 - $GC_I_SKILL_ID_SPEAR_OF_FURY_KURZICK
@@ -2892,7 +2972,8 @@ Func CanUse_SpearOfFuryKurzick()
 EndFunc
 
 Func BestTarget_SpearOfFuryKurzick($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2107 - $GC_I_SKILL_ID_WHIRLWIND_ATTACK
@@ -2906,7 +2987,7 @@ Func BestTarget_WhirlwindAttack($a_f_AggroRange)
 	; This article is about the Nightfall skill. For the temporarily available Bonus Mission Pack skill, see Whirlwind Attack (Turai Ossa).
 	; Concise description
 	; green; font-weight: bold;">13...20
-	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2111 - $GC_I_SKILL_ID_VAMPIRISM_ATTACK
@@ -2916,7 +2997,8 @@ Func CanUse_VampirismAttack()
 EndFunc
 
 Func BestTarget_VampirismAttack($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2116 - $GC_I_SKILL_ID_SNEAK_ATTACK
@@ -2930,7 +3012,7 @@ Func BestTarget_SneakAttack($a_f_AggroRange)
 	; Melee Attack. If this attack hits, target foe is Blinded for 5...8 seconds. This attack counts as a lead attack.
 	; Concise description
 	; Melee Attack. Inflicts Blindness (5...8 seconds). Counts as a lead attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2124 - $GC_I_SKILL_ID_SHATTERED_SPIRIT
@@ -2972,7 +3054,7 @@ Func BestTarget_TramplingOx($a_f_AggroRange)
 	; Dual Attack. Must follow an off-hand attack. If it hits, you deal +5...17...20 damage. If you a  hit a Crippled foe, that foe is knocked down.
 	; Concise description
 	; Dual Attack. Deals +5...17...20 damage; causes knock-down if target foe is Crippled. Must follow an off-hand attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2143 - $GC_I_SKILL_ID_DISRUPTING_SHOT
@@ -2986,7 +3068,7 @@ Func BestTarget_DisruptingShot($a_f_AggroRange)
 	; Bow Attack. If this attack hits, target foe's action is interrupted. If that action was a Skill, you strike for +10...34...40 damage.
 	; Concise description
 	; Bow Attack. Interrupts an action. Interruption effect: +10...34...40 damage if you interrupt a skill.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2144 - $GC_I_SKILL_ID_VOLLEY
@@ -3014,7 +3096,7 @@ Func BestTarget_CripplingVictory($a_f_AggroRange)
 	; Scythe Attack. If this attack hits a foe, that foe is Crippled for 3...7...8 seconds. If you have more Health than target foe, all adjacent foes take 10...26...30 earth damage.
 	; Concise description
 	; Scythe Attack. (3...7...8 seconds) Cripples target foe. If your health is greater than target foe's, all adjacent foes take 10...26...30 earth damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2150 - $GC_I_SKILL_ID_MAIMING_SPEAR
@@ -3028,7 +3110,7 @@ Func BestTarget_MaimingSpear($a_f_AggroRange)
 	; Spear Attack. If your attack hits a Bleeding foe, that foe is Crippled for 5...17...20 seconds.
 	; Concise description
 	; Spear Attack. Inflicts Crippled condition (5...17...20 seconds) if target foe is Bleeding.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2157 - $GC_I_SKILL_ID_GOLEM_STRIKE
@@ -3042,7 +3124,7 @@ Func BestTarget_GolemStrike($a_f_AggroRange)
 	; Melee Attack. Target takes 180 damage and is Dazed for 3 seconds.
 	; Concise description
 	; Melee Attack. Deals 180 damage and inflicts Dazed condition (3 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2158 - $GC_I_SKILL_ID_BLOODSTONE_SLASH
@@ -3056,7 +3138,7 @@ Func BestTarget_BloodstoneSlash($a_f_AggroRange)
 	; Melee Attack. If this attack hits, it steals 75 Health.
 	; Concise description
 	; Melee Attack. Steal 75 Health.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2182 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -3072,7 +3154,7 @@ Func BestTarget_RollingShift($a_f_AggroRange)
 	; Attack. Creature shifts form to attack.
 	; Concise description
 	; Attack. Shift forms to attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2194 - $GC_I_SKILL_ID_DISTRACTING_STRIKE
@@ -3086,7 +3168,7 @@ Func BestTarget_DistractingStrike($a_f_AggroRange)
 	; Melee Attack. If Distracting Strike hits, it deals no damage and interrupts target foe's action. If target foe has Cracked Armor, that skill is disabled for 20 seconds.
 	; Concise description
 	; Melee Attack. Interrupts an action. Interruption effect: Disables interrupted skill (20 seconds) if target foe has Cracked Armor. Deals no damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2195 - $GC_I_SKILL_ID_SYMBOLIC_STRIKE
@@ -3100,7 +3182,7 @@ Func BestTarget_SymbolicStrike($a_f_AggroRange)
 	; Melee Attack. If this attack hits, you deal +12 damage for each signet you have equipped (maximum 70 damage).
 	; Concise description
 	; Melee Attack. Deals +12 damage (maximum 70) for each signet you have equipped.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2197 - $GC_I_SKILL_ID_BODY_BLOW
@@ -3114,7 +3196,7 @@ Func BestTarget_BodyBlow($a_f_AggroRange)
 	; Melee Attack. If this attack hits, target foe takes +10...34...40 damage. If target foe has Cracked Armor, that foe suffers from a Deep Wound for 0...12...15 second[s].
 	; Concise description
 	; Melee Attack. Deals +10...34...40 damage. Inflicts Deep Wound (0...12...15 second[s]) if target foe has Cracked Armor.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2198 - $GC_I_SKILL_ID_BODY_SHOT
@@ -3128,7 +3210,7 @@ Func BestTarget_BodyShot($a_f_AggroRange)
 	; Bow Attack. If this attack hits, you deal +5...17...20 damage. If it hits a foe with Cracked Armor, you gain 5...9...10 Energy.
 	; Concise description
 	; Bow Attack. Deals +5...17...20 damage. You gain 5...9...10 Energy if target foe has Cracked Armor.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2209 - $GC_I_SKILL_ID_HOLY_SPEAR
@@ -3142,7 +3224,7 @@ Func BestTarget_HolySpear($a_f_AggroRange)
 	; Spear Attack. If this attack hits, you deal +5...17...20 damage. If it hits a summoned creature, all nearby foes take 15...75...90 holy damage, and are set on fire for 3 seconds.
 	; Concise description
 	; Spear Attack. Deals +5...17...20 damage. Deals 15...75...90 holy damage and inflicts Burning condition (3 seconds) to nearby foes if you hit a summoned creature.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2210 - $GC_I_SKILL_ID_SPEAR_SWIPE
@@ -3156,7 +3238,7 @@ Func BestTarget_SpearSwipe($a_f_AggroRange)
 	; Spear Attack. If this attack hits, you deal +5...17...20 damage and target foe is Dazed for 4...9...10 seconds. This attack has melee range.
 	; Concise description
 	; Spear Melee Attack. Deals +5...17...20 damage and inflicts Dazed condition (4...9...10 seconds). This attack has melee range.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2228 - $GC_I_SKILL_ID_DEFT_STRIKE
@@ -3170,7 +3252,7 @@ Func BestTarget_DeftStrike($a_f_AggroRange)
 	; Ranged Attack. If this attack hits, target foe takes 18...30 damage. If that foe has Cracked Armor, it begins Bleeding for 18...30 seconds.
 	; Concise description
 	; Ranged Attack. Deals 18...30 damage. Inflicts Bleeding condition (18...30 seconds) if target foe has Cracked Armor.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2238 - $GC_I_SKILL_ID_SPEAR_OF_REDEMPTION
@@ -3184,7 +3266,7 @@ Func BestTarget_SpearOfRedemption($a_f_AggroRange)
 	; Spear Attack. If this attack hits, you deal +5...17...20 damage. If it fails to hit, you lose one condition.
 	; Concise description
 	; Spear Attack. Deals +5...17...20 damage. If it fails to hit, you lose one condition.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2239 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -3318,7 +3400,7 @@ Func BestTarget_ClubOfAThousandBears($a_f_AggroRange)
 	; This article is about a PvE-only skill. For the weapon of the same name, see Club of a Thousand Bears (weapon).
 	; Concise description
 	; green; font-weight: bold;">6...9
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2365 - $GC_I_SKILL_ID_THUNDERFIST_STRIKE
@@ -3332,7 +3414,7 @@ Func BestTarget_ThunderfistStrike($a_f_AggroRange)
 	; Melee Attack. You deliver a Thunderfist Strike to your opponent, dealing 100 damage if it hits.
 	; Concise description
 	; Melee Attack. Deals 100 damage.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2490 - $GC_I_SKILL_ID_PARASITIC_BITE
@@ -3346,7 +3428,7 @@ Func BestTarget_ParasiticBite($a_f_AggroRange)
 	; Melee Attack. If this attack is successful, target foe has -1 Health degeneration and you have +1 Health regeneration for 5 seconds.
 	; Concise description
 	; Melee Attack. (5 seconds.) This attack inflicts -1 Health degeneration and you gain + 1 Health regeneration.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2515 - $GC_I_SKILL_ID_THE_SNIPERS_SPEAR
@@ -3356,7 +3438,8 @@ Func CanUse_TheSnipersSpear()
 EndFunc
 
 Func BestTarget_TheSnipersSpear($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2640 - ;  $GC_I_SKILL_ID_CRIPPLING_SLASH
@@ -3370,7 +3453,8 @@ Func CanUse_WhirlwindAttackTuraiOssa()
 EndFunc
 
 Func BestTarget_WhirlwindAttackTuraiOssa($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2685 - $GC_I_SKILL_ID_DRAGON_SLASH_TURAI_OSSA
@@ -3380,7 +3464,8 @@ Func CanUse_DragonSlashTuraiOssa()
 EndFunc
 
 Func BestTarget_DragonSlashTuraiOssa($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2732 - $GC_I_SKILL_ID_FALKENS_FIRE_FIST
@@ -3390,7 +3475,8 @@ Func CanUse_FalkensFireFist()
 EndFunc
 
 Func BestTarget_FalkensFireFist($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2808 - $GC_I_SKILL_ID_ENRAGED_SMASH_PvP
@@ -3400,7 +3486,8 @@ Func CanUse_EnragedSmashPvP()
 EndFunc
 
 Func BestTarget_EnragedSmashPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2861 - $GC_I_SKILL_ID_PENETRATING_ATTACK_PvP
@@ -3410,7 +3497,8 @@ Func CanUse_PenetratingAttackPvP()
 EndFunc
 
 Func BestTarget_PenetratingAttackPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2864 - $GC_I_SKILL_ID_SUNDERING_ATTACK_PvP
@@ -3420,7 +3508,8 @@ Func CanUse_SunderingAttackPvP()
 EndFunc
 
 Func BestTarget_SunderingAttackPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2873 - $GC_I_SKILL_ID_MYSTIC_SWEEP_PvP
@@ -3430,7 +3519,8 @@ Func CanUse_MysticSweepPvP()
 EndFunc
 
 Func BestTarget_MysticSweepPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2874 - $GC_I_SKILL_ID_EREMITES_ATTACK_PvP
@@ -3440,7 +3530,8 @@ Func CanUse_EremitesAttackPvP()
 EndFunc
 
 Func BestTarget_EremitesAttackPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2875 - $GC_I_SKILL_ID_HARRIERS_TOSS_PvP
@@ -3450,7 +3541,8 @@ Func CanUse_HarriersTossPvP()
 EndFunc
 
 Func BestTarget_HarriersTossPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2888 - $GC_I_SKILL_ID_CHILLING_VICTORY_PvP
@@ -3460,7 +3552,8 @@ Func CanUse_ChillingVictoryPvP()
 EndFunc
 
 Func BestTarget_ChillingVictoryPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2925 - $GC_I_SKILL_ID_SLOTH_HUNTERS_SHOT_PvP
@@ -3470,7 +3563,8 @@ Func CanUse_SlothHuntersShotPvP()
 EndFunc
 
 Func BestTarget_SlothHuntersShotPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2929 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -3484,7 +3578,8 @@ Func CanUse_PainAttackTogo1()
 EndFunc
 
 Func BestTarget_PainAttackTogo1($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3056 - $GC_I_SKILL_ID_PAIN_ATTACK_TOGO2
@@ -3494,7 +3589,8 @@ Func CanUse_PainAttackTogo2()
 EndFunc
 
 Func BestTarget_PainAttackTogo2($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3057 - $GC_I_SKILL_ID_PAIN_ATTACK_TOGO3
@@ -3504,7 +3600,8 @@ Func CanUse_PainAttackTogo3()
 EndFunc
 
 Func BestTarget_PainAttackTogo3($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3061 - $GC_I_SKILL_ID_DEATH_BLOSSOM_PvP
@@ -3514,7 +3611,8 @@ Func CanUse_DeathBlossomPvP()
 EndFunc
 
 Func BestTarget_DeathBlossomPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3074 - $GC_I_SKILL_ID_BONE_SPIKE
@@ -3528,7 +3626,7 @@ Func BestTarget_BoneSpike($a_f_AggroRange)
 	; Bow Attack. A Bone Spike shoots out, dealing 100 damage to target foe. The Bone Spike seems to penetrate all defenses.
 	; Concise description
 	; Bow Attack. A Bone Spike shoots out, dealing 100 damage to target foe. The Bone Spike seems to penetrate all defenses.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3075 - $GC_I_SKILL_ID_FLURRY_OF_SPLINTERS
@@ -3542,7 +3640,7 @@ Func BestTarget_FlurryOfSplinters($a_f_AggroRange)
 	; Bow Attack. A flurry of Bone Splinters shoots out, hitting target foe and up to 5 foes in longbow range for 35 damage per hit over 3 seconds. The Bone Splinters seem to penetrate all defenses.
 	; Concise description
 	; Bow Attack. A flurry of Bone Splinters shoots out, hitting target foe and up to 5 foes in longbow range for 35 damage per hit over 3 seconds. The Bone Splinters seem to penetrate all defenses.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3084 - $GC_I_SKILL_ID_REAPING_OF_DHUUM
@@ -3556,7 +3654,7 @@ Func BestTarget_ReapingOfDhuum($a_f_AggroRange)
 	; Scythe Attack. Dhuum deals 200 damage to a new target with each strike. Dhuum only strikes a foe once in this way and will stop this attack after the fourth strike or when no eligible targets are within the area of his last strike. Dhuum is untargetable during this attack.
 	; Concise description
 	; Scythe Attack. Dhuum deals 200 damage to a new target with each strike. Dhuum only strikes a foe once in this way and will stop this attack after the fourth strike or when no eligible targets are within the area of his last strike. Dhuum is untargetable during this attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3133 - $GC_I_SKILL_ID_WEIGHT_OF_DHUUM
@@ -3570,7 +3668,7 @@ Func BestTarget_WeightOfDhuum($a_f_AggroRange)
 	; Scythe Attack. For 5 seconds, target foe moves and attacks 90% slower, has tripled casting times, benefits 75% less from healing, and has -10 Health degeneration.
 	; Concise description
 	; Scythe Attack. (5 seconds.) Target foe moves and attacks 90% slower, has tripled casting times, benefits 75% less from healing, and has -10 Health degeneration.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3140 - $GC_I_SKILL_ID_STAGGERING_BLOW_PvP
@@ -3580,7 +3678,8 @@ Func CanUse_StaggeringBlowPvP()
 EndFunc
 
 Func BestTarget_StaggeringBlowPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3142 - $GC_I_SKILL_ID_FIERCE_BLOW_PvP
@@ -3590,7 +3689,8 @@ Func CanUse_FierceBlowPvP()
 EndFunc
 
 Func BestTarget_FierceBlowPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3143 - $GC_I_SKILL_ID_RENEWING_SMASH_PvP
@@ -3600,7 +3700,8 @@ Func CanUse_RenewingSmashPvP()
 EndFunc
 
 Func BestTarget_RenewingSmashPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3147 - $GC_I_SKILL_ID_KEEN_ARROW_PvP
@@ -3610,7 +3711,8 @@ Func CanUse_KeenArrowPvP()
 EndFunc
 
 Func BestTarget_KeenArrowPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3153 - $GC_I_SKILL_ID_PAIN_ATTACK_SIGNET_OF_SPIRITS1
@@ -3619,7 +3721,8 @@ Func CanUse_PainAttackSignetOfSpirits1()
 EndFunc
 
 Func BestTarget_PainAttackSignetOfSpirits1($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3154 - $GC_I_SKILL_ID_PAIN_ATTACK_SIGNET_OF_SPIRITS2
@@ -3629,7 +3732,8 @@ Func CanUse_PainAttackSignetOfSpirits2()
 EndFunc
 
 Func BestTarget_PainAttackSignetOfSpirits2($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3155 - $GC_I_SKILL_ID_PAIN_ATTACK_SIGNET_OF_SPIRITS3
@@ -3639,7 +3743,8 @@ Func CanUse_PainAttackSignetOfSpirits3()
 EndFunc
 
 Func BestTarget_PainAttackSignetOfSpirits3($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3163 - $GC_I_SKILL_ID_KEIRANS_SNIPER_SHOT
@@ -3649,7 +3754,8 @@ Func CanUse_KeiransSniperShot()
 EndFunc
 
 Func BestTarget_KeiransSniperShot($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3164 - $GC_I_SKILL_ID_FALKEN_PUNCH
@@ -3663,7 +3769,7 @@ Func BestTarget_FalkenPunch($a_f_AggroRange)
 	; Melee Attack. Deals +100 damage to target foe, knocks them down and sets that foe on fire for 5 seconds.
 	; Concise description
 	; Melee Attack. Target foe takes +100 damage, is knocked down, and on fire for 5 seconds.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3235 - $GC_I_SKILL_ID_KEIRANS_SNIPER_SHOT_HEARTS_OF_THE_NORTH
@@ -3673,7 +3779,8 @@ Func CanUse_KeiransSniperShotHeartsOfTheNorth()
 EndFunc
 
 Func BestTarget_KeiransSniperShotHeartsOfTheNorth($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3236 - $GC_I_SKILL_ID_GRAVESTONE_MARKER
@@ -3687,7 +3794,9 @@ Func BestTarget_GravestoneMarker($a_f_AggroRange)
 	; Bow Attack. Deals +35 piercing damage and Cripples target foe for 15 seconds. If target foe is suffering from Weakness, that foe is knocked down for 3 seconds.
 	; Concise description
 	; Bow Attack. Deals +35 damage to target foe. Inflicts Crippled (15 seconds). Knocks down (3 seconds) targets suffering Weakness.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsWeakened")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3237 - $GC_I_SKILL_ID_TERMINAL_VELOCITY
@@ -3701,7 +3810,9 @@ Func BestTarget_TerminalVelocity($a_f_AggroRange)
 	; Bow Attack. Deals +30 piercing damage and interrupts target foe. If target foe is Bleeding, they suffer a Deep Wound for 20 seconds. This arrow moves twice as fast.
 	; Concise description
 	; Bow Attack. Deals +30 damage. Interrupts target. Inflicts Deep Wound (20 seconds) on Bleeding foes. This arrow moves twice as fast.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsBleeding")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3238 - $GC_I_SKILL_ID_RELENTLESS_ASSAULT
@@ -3715,7 +3826,7 @@ Func BestTarget_RelentlessAssault($a_f_AggroRange)
 	; Bow Attack. You lose up to 3 conditions. If this attack hits, you strike for +20 piercing damage and the target foe suffers Poison for 20 seconds.
 	; Concise description
 	; Bow Attack. Lose up to 3 conditions. Deals +20 damage and Poisons target foe (20 seconds) if the attack hits.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3244 - $GC_I_SKILL_ID_WITHERING_BLADE
@@ -3729,7 +3840,7 @@ Func BestTarget_WitheringBlade($a_f_AggroRange)
 	; Off-Hand Attack. Deals +50 damage, and inflicts Weakness on target foe for 20 seconds.
 	; Concise description
 	; Off-Hand Attack. Deals +50 damage. Inflicts Weakness (20 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3246 - $GC_I_SKILL_ID_VENOM_FANG
@@ -3743,7 +3854,9 @@ Func BestTarget_VenomFang($a_f_AggroRange)
 	; Dual Attack. Target foe becomes Poisoned for 20 seconds. If target foe has a Deep Wound, this attack deals an additional 80 damage.
 	; Concise description
 	; Dual Attack. Target is Poisoned (20 seconds). Deals +80 damage if target foe has a Deep Wound.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsDeepWounded")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3249 - $GC_I_SKILL_ID_RAIN_OF_ARROWS
@@ -3757,7 +3870,7 @@ Func BestTarget_RainOfArrows($a_f_AggroRange)
 	; Bow Attack. Shoot arrows at target foe and up to 3 foes near your target. Each arrow strikes for +20 damage if it hits.
 	; Concise description
 	; Bow Attack. Deals +20 damage. Hits up to 3 foes near your target.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3250 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -3768,7 +3881,8 @@ Func CanUse_FoxFangsPvP()
 EndFunc
 
 Func BestTarget_FoxFangsPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3252 - $GC_I_SKILL_ID_WILD_STRIKE_PvP
@@ -3778,7 +3892,8 @@ Func CanUse_WildStrikePvP()
 EndFunc
 
 Func BestTarget_WildStrikePvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3263 - $GC_I_SKILL_ID_BANISHING_STRIKE_PvP
@@ -3788,7 +3903,8 @@ Func CanUse_BanishingStrikePvP()
 EndFunc
 
 Func BestTarget_BanishingStrikePvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3264 - $GC_I_SKILL_ID_TWIN_MOON_SWEEP_PvP
@@ -3798,7 +3914,8 @@ Func CanUse_TwinMoonSweepPvP()
 EndFunc
 
 Func BestTarget_TwinMoonSweepPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3265 - $GC_I_SKILL_ID_IRRESISTIBLE_SWEEP_PvP
@@ -3808,7 +3925,8 @@ Func CanUse_IrresistibleSweepPvP()
 EndFunc
 
 Func BestTarget_IrresistibleSweepPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3266 - $GC_I_SKILL_ID_PIOUS_ASSAULT_PvP
@@ -3818,7 +3936,8 @@ Func CanUse_PiousAssaultPvP()
 EndFunc
 
 Func BestTarget_PiousAssaultPvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3295 - $GC_I_SKILL_ID_CLUB_STRIKE
@@ -3832,7 +3951,9 @@ Func BestTarget_ClubStrike($a_f_AggroRange)
 	; Attack. You strike for +25 damage. If target foe is suffering from one or more conditions, you strike for an additional +25 damage and target foe is knocked down.
 	; Concise description
 	; Attack. Strikes for +25 damage. Strikes for an additional +25 damage and causes knock-down if target is suffering from a condition.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_HasCondition")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3296 - $GC_I_SKILL_ID_BLUDGEON
@@ -3846,7 +3967,9 @@ Func BestTarget_Bludgeon($a_f_AggroRange)
 	; Attack. You strike for +50 damage. If target foe is knocked down, you strike for an additional +50 damage and target foe suffers a Deep Wound for 10 seconds.
 	; Concise description
 	; Attack. Strikes for +50 damage. Strikes for an additional +50 damage and applies a Deep Wound (10 seconds) if target is knocked down.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsKnockedDown")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3301 - $GC_I_SKILL_ID_ANNIHILATOR_BASH
@@ -3860,7 +3983,7 @@ Func BestTarget_AnnihilatorBash($a_f_AggroRange)
 	; Melee Attack. Removes blind condition and ends target's current stance. Target foe is knocked down and struck for +50 damage.
 	; Concise description
 	; Melee Attack. Deals +50 damage. Knocks down foe. Initial Effect: Removes blind condition and ends target foe's stance.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3367 - $GC_I_SKILL_ID_WOUNDING_STRIKE_PvP
@@ -3870,7 +3993,8 @@ Func CanUse_WoundingStrikePvP()
 EndFunc
 
 Func BestTarget_WoundingStrikePvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3381 - $GC_I_SKILL_ID_ANNIHILATOR_STRIKE
@@ -3884,7 +4008,7 @@ Func BestTarget_AnnihilatorStrike($a_f_AggroRange)
 	; Attack. If this attack hits, it steals 75 Health. Steal twice as much Health if it strike  Sarah.
 	; Concise description
 	; Attack. Steal 75 Health. If you strike Sarah, steal twice as much Health.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3383 - $GC_I_SKILL_ID_ANNIHILATOR_KNUCKLE
@@ -3898,7 +4022,7 @@ Func BestTarget_AnnihilatorKnuckle($a_f_AggroRange)
 	; Attack. Strikes target and adjacent foes for +80 damage.
 	; Concise description
 	; Attack. Deals +80 damage to target and adjacent foes.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3425 - $GC_I_SKILL_ID_JUDGMENT_STRIKE
@@ -3912,6 +4036,8 @@ Func BestTarget_JudgmentStrike($a_f_AggroRange)
 	; Elite Melee Attack. Attack target and adjacent foes. Each attack that hits deals +13...27...30 Holy damage  and knocks down attacking foes. PvE Skill
 	; Concise description
 	; Elite Melee Attack. Attacks target and adjacent foes for +13...27...30 Holy damage. Causes knock down on attacking foes. PvE Skill
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
+
+
 

--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Enchantment.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Enchantment.au3
@@ -77,7 +77,9 @@ Func BestTarget_SympatheticVisage($a_f_AggroRange)
 	; Enchantment Spell. For 4...9...10 seconds, whenever target ally is hit by a melee attack, all adjacent foes lose all adrenaline and 3 Energy.
 	; Concise description
 	; Enchantment Spell. (4...9...10 seconds.) All adjacent foes lose all adrenaline and 3 Energy whenever a melee attack hits target ally.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 37 - $GC_I_SKILL_ID_ILLUSION_OF_HASTE
@@ -171,7 +173,9 @@ Func BestTarget_DeathNova($a_f_AggroRange)
 	; Enchantment Spell. For 30 seconds, if target ally dies, all adjacent foes take 26...85...100 damage and are Poisoned for 15 seconds.
 	; Concise description
 	; Enchantment Spell. (30 seconds.) Deals 26...85...100 damage and inflicts Poisoned condition (15 seconds) on adjacent foes if target ally dies.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 111 - $GC_I_SKILL_ID_AWAKEN_THE_BLOOD
@@ -199,7 +203,9 @@ Func BestTarget_TaintedFlesh($a_f_AggroRange)
 	; Elite Enchantment Spell. For 20...39...44 seconds, target ally is immune to disease, and anyone striking that ally in melee becomes Diseased for 3...13...15 seconds.
 	; Concise description
 	; Elite Enchantment Spell. (20...39...44 seconds.) Foes who hit target ally in melee become Diseased (3...13...15 seconds); this ally is immune to Disease.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 114 - $GC_I_SKILL_ID_AURA_OF_THE_LICH
@@ -256,7 +262,9 @@ Func BestTarget_BloodIsPower($a_f_AggroRange)
 	; Elite Enchantment Spell. For 10 seconds, target other ally gains +3...5...6 Energy regeneration.
 	; Concise description
 	; Elite Enchantment Spell. (10 seconds.) +3...5...6 Energy regeneration. Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 130 - $GC_I_SKILL_ID_DEMONIC_FLESH
@@ -354,7 +362,9 @@ Func BestTarget_BloodRitual($a_f_AggroRange)
 	; Enchantment Spell. For 8...13...14 seconds, target touched ally gains +3 Energy regeneration. Blood Ritual cannot be used on the caster.
 	; Concise description
 	; Enchantment Spell. (8...13...14 seconds.) +3 Energy regeneration. Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 160 - $GC_I_SKILL_ID_WINDBORNE_SPEED
@@ -368,7 +378,9 @@ Func BestTarget_WindborneSpeed($a_f_AggroRange)
 	; Enchantment Spell. For 5...11...13 seconds, target ally moves 33% faster.
 	; Concise description
 	; Enchantment Spell. (5...11...13 seconds.) Target ally moves 33% faster.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 164 - $GC_I_SKILL_ID_ELEMENTAL_ATTUNEMENT
@@ -564,7 +576,7 @@ Func BestTarget_IceSpear($a_f_AggroRange)
 	; Enchantment Spell. Send out an Ice Spear, striking target foe for 10...50...60 cold damage if it hits. If you are Overcast, you gain +1...3...4 Health regeneration for 5 seconds.
 	; Concise description
 	; Enchantment Spell. Projectile: deals 10...50...60 cold damage. Gain +1...3...4 Health regeneration for 5 seconds if Overcast.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 216 - $GC_I_SKILL_ID_IRON_MIST
@@ -676,7 +688,9 @@ Func BestTarget_LifeBond($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, whenever target other ally takes damage from an attack, half the damage is redirected to you. The damage you receive this way is reduced by 3...25...30.
 	; Concise description
 	; Enchantment Spell. Half of the damage target ally takes from attacks is redirected to you. Redirected damage is reduced by 3...25...30. Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 242 - $GC_I_SKILL_ID_BALTHAZARS_SPIRIT
@@ -690,7 +704,9 @@ Func BestTarget_BalthazarsSpirit($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, target ally gains adrenaline and 1 Energy after taking damage. (The amount of adrenaline gained increases depending on your rank in Smiting Prayers.)
 	; Concise description
 	; Enchantment Spell. Target ally gains adrenaline and 1 Energy when taking damage.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 243 - $GC_I_SKILL_ID_STRENGTH_OF_HONOR
@@ -704,7 +720,9 @@ Func BestTarget_StrengthOfHonor($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, target ally deals 5...21...25 more damage in melee.
 	; Concise description
 	; Enchantment Spell. Target ally deals 5...21...25 more damage in melee.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 244 - $GC_I_SKILL_ID_LIFE_ATTUNEMENT
@@ -718,7 +736,9 @@ Func BestTarget_LifeAttunement($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, target ally deals 30% less damage with attacks, but gains 14...43...50% more Health when healed.
 	; Concise description
 	; Enchantment Spell. Target ally gains 14...43...50% more Health when healed. This ally deals 30% less damage with attacks.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 245 - $GC_I_SKILL_ID_PROTECTIVE_SPIRIT
@@ -732,7 +752,9 @@ Func BestTarget_ProtectiveSpirit($a_f_AggroRange)
 	; Enchantment Spell. For 5...19...23 seconds, target ally cannot lose more than 10% max Health due to damage from a single attack or spell.
 	; Concise description
 	; Enchantment Spell. (5...19...23 seconds.) Incoming damage is reduced to 10% of target ally's maximum Health.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 246 - $GC_I_SKILL_ID_DIVINE_INTERVENTION
@@ -746,7 +768,9 @@ Func BestTarget_DivineIntervention($a_f_AggroRange)
 	; Enchantment Spell. For 10 seconds, the next time target ally receives damage that would be fatal, the damage is negated and that ally is healed for 26...197...240 Health.
 	; Concise description
 	; Enchantment Spell. (10 seconds.) Negates the next fatal damage target ally takes. Negation effect: heals for 26...197...240.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 248 - $GC_I_SKILL_ID_RETRIBUTION
@@ -760,7 +784,9 @@ Func BestTarget_Retribution($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, whenever target ally takes attack damage, this spell deals 33% of the damage back to the source (maximum 5...17...20 damage).
 	; Concise description
 	; Enchantment Spell. Deals 33% of each attack's damage (maximum 5...17...20) back to the source.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 249 - $GC_I_SKILL_ID_HOLY_WRATH
@@ -774,7 +800,9 @@ Func BestTarget_HolyWrath($a_f_AggroRange)
 	; Enchantment Spell. For 10...26...30 seconds, the next 1...8...10 time[s] target other ally takes attack damage, this spell deals 66% of the damage back to the source (maximum of 5...41...50 damage).
 	; Concise description
 	; Enchantment Spell. (10...26...30 seconds). Deals 66% of each attack's damage (maximum 5...41...50) back to source. Ends after dealing damage 1...8...10 time[s]. Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 250 - $GC_I_SKILL_ID_ESSENCE_BOND
@@ -788,7 +816,9 @@ Func BestTarget_EssenceBond($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, whenever target ally takes physical or elemental damage, you gain 1 Energy.
 	; Concise description
 	; Enchantment Spell. You gain 1 Energy whenever target ally takes physical or elemental damage.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 254 - $GC_I_SKILL_ID_VIGOROUS_SPIRIT
@@ -802,7 +832,9 @@ Func BestTarget_VigorousSpirit($a_f_AggroRange)
 	; Enchantment Spell. For 30 seconds, each time target ally attacks or casts a spell, that ally is healed for 5...17...20 Health.
 	; Concise description
 	; Enchantment Spell. (30 seconds.) Heals for 5...17...20 each time target ally attacks or casts a spell.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 255 - $GC_I_SKILL_ID_WATCHFUL_SPIRIT
@@ -816,7 +848,9 @@ Func BestTarget_WatchfulSpirit($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, target ally gains +2 Health regeneration. That ally is healed for 30...150...180 Health when Watchful Spirit ends.
 	; Concise description
 	; Enchantment Spell. +2 Health regeneration. End effect: heals for 30...150...180.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 256 - $GC_I_SKILL_ID_BLESSED_AURA
@@ -858,7 +892,9 @@ Func BestTarget_Guardian($a_f_AggroRange)
 	; This article is about a monk skill. For the character title, see Guardian (title).
 	; Concise description
 	; green; font-weight: bold;">2...6...7
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 259 - $GC_I_SKILL_ID_SHIELD_OF_DEFLECTION
@@ -872,7 +908,9 @@ Func BestTarget_ShieldOfDeflection($a_f_AggroRange)
 	; Elite Enchantment Spell. For 3...9...10 seconds, target ally has a 75% chance to block attacks and gains 15...27...30 armor.
 	; Concise description
 	; Elite Enchantment Spell. (3...9...10 seconds.) 75% chance to block. +15...27...30 armor.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 260 - $GC_I_SKILL_ID_AURA_OF_FAITH
@@ -886,7 +924,9 @@ Func BestTarget_AuraOfFaith($a_f_AggroRange)
 	; Elite Enchantment Spell. For 3 seconds, target ally gains 50...90...100% more Health when healed and takes 5...41...50% less damage.
 	; Concise description
 	; Elite Enchantment Spell. (3 seconds.) Target ally gains 50...90...100% more Health when healed and takes 5...41...50% less damage.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 261 - $GC_I_SKILL_ID_SHIELD_OF_REGENERATION
@@ -900,7 +940,9 @@ Func BestTarget_ShieldOfRegeneration($a_f_AggroRange)
 	; Elite Enchantment Spell. For 5...11...13 seconds, target ally gains +3...9...10 Health regeneration and 40 armor.
 	; Concise description
 	; Elite Enchantment Spell. (5...11...13 seconds.) +3...9...10 Health regeneration and +40 armor.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 262 - $GC_I_SKILL_ID_SHIELD_OF_JUDGMENT
@@ -914,7 +956,9 @@ Func BestTarget_ShieldOfJudgment($a_f_AggroRange)
 	; Elite Enchantment Spell. For 8...18...20 seconds, anyone striking target ally with an attack is knocked down and suffers 5...41...50 holy damage.
 	; Concise description
 	; Elite Enchantment Spell. (8...18...20 seconds.) Deals 5...41...50 holy damage to foes attacking [sic] target ally. Causes knock-down.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 263 - $GC_I_SKILL_ID_PROTECTIVE_BOND
@@ -928,7 +972,9 @@ Func BestTarget_ProtectiveBond($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, target ally cannot lose more than 5% max Health due to damage from a single attack or spell. When Protective Bond prevents damage, you lose 6...4...3 Energy or the spell ends.
 	; Concise description
 	; Enchantment Spell. Target ally cannot lose more than 5% max Health from a single attack or spell. Each time damage is reduced you lose 6...4...3 Energy or this spell ends.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 266 - $GC_I_SKILL_ID_PEACE_AND_HARMONY
@@ -951,7 +997,9 @@ Func BestTarget_PeaceAndHarmony($a_f_AggroRange)
 	$l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_IsConditioned")
 	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.5 Then Return $l_i_Target
 
-	Return 0
+	$l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 267 - $GC_I_SKILL_ID_JUDGES_INSIGHT
@@ -961,7 +1009,8 @@ Func CanUse_JudgesInsight()
 EndFunc
 
 Func BestTarget_JudgesInsight($a_f_AggroRange)
-	Return 0
+	; Judges Insight is a self-targeted enchantment
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 268 - $GC_I_SKILL_ID_UNYIELDING_AURA
@@ -989,7 +1038,9 @@ Func BestTarget_MarkOfProtection($a_f_AggroRange)
 	; Elite Enchantment Spell. For 10 seconds, whenever target ally would take damage, that ally is healed for that amount instead, maximum 6...49...60. All your Protection Prayers are disabled for 5 seconds.
 	; Concise description
 	; Elite Enchantment Spell. (10 seconds.) Converts incoming damage to healing (maximum 6...49...60). All your Protection Prayers are disabled (5 seconds).
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 270 - $GC_I_SKILL_ID_LIFE_BARRIER
@@ -1003,7 +1054,9 @@ Func BestTarget_LifeBarrier($a_f_AggroRange)
 	; Elite Enchantment Spell. While you maintain this enchantment, damage dealt to target other ally is reduced by 20...44...50%. If your Health is below 50% when that ally takes damage, Life Barrier ends.
 	; Concise description
 	; Elite Enchantment Spell. Reduces damage by 20...44...50%. Cannot self-target. If your Health is below 50% when target takes damage, Life Barrier ends.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 271 - $GC_I_SKILL_ID_ZEALOTS_FIRE
@@ -1027,7 +1080,8 @@ Func CanUse_BalthazarsAura()
 EndFunc
 
 Func BestTarget_BalthazarsAura($a_f_AggroRange)
-	Return 0
+	; Balthazar's Aura is a self-targeted enchantment
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 273 - $GC_I_SKILL_ID_SPELL_BREAKER
@@ -1041,7 +1095,9 @@ Func BestTarget_SpellBreaker($a_f_AggroRange)
 	; Elite Enchantment Spell. For 5...15...17 seconds, target ally cannot be the target of enemy spells.
 	; Concise description
 	; Elite Enchantment Spell. (5...15...17 seconds.) Target ally cannot be the target of enemy spells.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 274 - $GC_I_SKILL_ID_HEALING_SEED
@@ -1055,7 +1111,9 @@ Func BestTarget_HealingSeed($a_f_AggroRange)
 	; Enchantment Spell. For 10 seconds, whenever target other ally takes damage, that ally and all adjacent allies gain 3...25...30 Health.
 	; Concise description
 	; Enchantment Spell. (10 seconds.) Target and adjacent allies gain 3...25...30 Health whenever this ally takes damage. Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 284 - $GC_I_SKILL_ID_DIVINE_BOON
@@ -1083,7 +1141,9 @@ Func BestTarget_HealingHands($a_f_AggroRange)
 	; Elite Enchantment Spell. For 10 seconds, whenever target ally takes damage, that ally is healed for 5...29...35 Health.
 	; Concise description
 	; Elite Enchantment Spell. (10 seconds.) Heals for 5...29...35 whenever target takes damage.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 288 - $GC_I_SKILL_ID_HEALING_BREEZE
@@ -1112,7 +1172,9 @@ Func BestTarget_VitalBlessing($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, target ally has +40...168...200 maximum Health.
 	; Concise description
 	; Enchantment Spell. +40...168...200 maximum Health.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 290 - $GC_I_SKILL_ID_MENDING
@@ -1126,7 +1188,9 @@ Func BestTarget_Mending($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, target ally gains +1...3...4 Health regeneration.
 	; Concise description
 	; Enchantment Spell. +1...3...4 Health regeneration.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 291 - $GC_I_SKILL_ID_LIVE_VICARIOUSLY
@@ -1140,7 +1204,9 @@ Func BestTarget_LiveVicariously($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, whenever target ally hits a foe, you gain 2...14...17 Health.
 	; Concise description
 	; Enchantment Spell. You gain 2...14...17 Health whenever target ally hits a foe.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 299 - $GC_I_SKILL_ID_SHIELDING_HANDS
@@ -1154,7 +1220,9 @@ Func BestTarget_ShieldingHands($a_f_AggroRange)
 	; Enchantment Spell. For 8 seconds, damage and life steal received by target ally is reduced by 3...15...18. When Shielding Hands ends, that ally is healed for 5...41...50 Health.
 	; Concise description
 	; Enchantment Spell. (8 seconds.) Reduces incoming damage and life steal by 3...15...18. End effect: heals for 5...41...50
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 307 - $GC_I_SKILL_ID_REVERSAL_OF_FORTUNE
@@ -1168,7 +1236,9 @@ Func BestTarget_ReversalOfFortune($a_f_AggroRange)
 	; "RoF" redirects here. For the Prophecies mission, see Ring of Fire.
 	; Concise description
 	; green; font-weight: bold;">15...67...80
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 308 - $GC_I_SKILL_ID_SUCCOR
@@ -1182,7 +1252,9 @@ Func BestTarget_Succor($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this Enchantment, target other ally gains +1 Health and +1 Energy regeneration, but you lose 1 Energy each time that ally casts a Spell.
 	; Concise description
 	; Enchantment Spell. +1 Health regeneration and +1 Energy regeneration. Cannot self-target. You lose 1 Energy each time target ally casts a spell.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 309 - $GC_I_SKILL_ID_HOLY_VEIL
@@ -1196,7 +1268,12 @@ Func BestTarget_HolyVeil($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, any hex cast on target ally takes twice as long to cast. When Holy Veil ends, one hex is removed from target ally.
 	; Concise description
 	; Enchantment Spell. Doubles casting time of hexes cast on target ally. End effect: removes a hex.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	
+	$l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 310 - $GC_I_SKILL_ID_DIVINE_SPIRIT
@@ -1225,7 +1302,7 @@ Func BestTarget_Vengeance($a_f_AggroRange)
 	; This article is about the Monk skill. For the weapon, see Anniversary Daggers "Vengeance".
 	; Concise description
 	; #808080;">End effect: this ally dies.
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 515 - $GC_I_SKILL_ID_CHARR_BUFF
@@ -1239,7 +1316,7 @@ Func BestTarget_CharrBuff($a_f_AggroRange)
 	; Monster skill
 	; Concise description
 	; 1em; margin-bottom:1em; clear:both;" />
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 532 - $GC_I_SKILL_ID_HEALING_BREEZE_AGNARS_RAGE
@@ -1249,7 +1326,8 @@ Func CanUse_HealingBreezeAgnarsRage()
 EndFunc
 
 Func BestTarget_HealingBreezeAgnarsRage($a_f_AggroRange)
-	Return 0
+	; Healing Breeze variant - targets lowest HP ally
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 584 - $GC_I_SKILL_ID_DIVINE_FIRE
@@ -1277,7 +1355,7 @@ Func BestTarget_ChimeraOfIntensity($a_f_AggroRange)
 	; Enchantment Spell. Your skills recharge 50% faster, spells you cast cost 50% less Energy, and your movement speed is increased by 50%.
 	; Concise description
 	; Enchantment Spell. Your skills recharge 50% faster, spells you cast cost 50% less Energy, and your movement speed is increased by 50%.
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 763 - $GC_I_SKILL_ID_JAUNDICED_GAZE
@@ -1291,7 +1369,7 @@ Func BestTarget_JaundicedGaze($a_f_AggroRange)
 	; Enchantment Spell. Remove an enchantment from target foe. If an enchantment is removed, for the next 1...12...15 second[s], your next enchantment spell casts 0...1...1 second[s] faster and costs 1...8...10 less Energy.
 	; Concise description
 	; Enchantment Spell. Removes an enchantment from target foe. Removal effect: your next enchantment casts 0...1...1 second[s] faster and costs 1...8...10 less Energy. (1...12...15 second[s])
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 771 - $GC_I_SKILL_ID_AURA_OF_DISPLACEMENT
@@ -1305,7 +1383,7 @@ Func BestTarget_AuraOfDisplacement($a_f_AggroRange)
 	; Elite Enchantment Spell. When you cast Aura of Displacement, Shadow Step to target foe. When you stop maintaining Aura of Displacement you return to your original location.
 	; Concise description
 	; Elite Enchantment Spell. Shadow Step to target foe. End effect: return to your original location.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 806 - $GC_I_SKILL_ID_CULTISTS_FERVOR
@@ -1354,7 +1432,7 @@ Func BestTarget_VampiricSpirit($a_f_AggroRange)
 	; Elite Enchantment Spell. Steal up to 5...41...50 Health from target foe. For 10 seconds, you have +5...9...10 Health regeneration.
 	; Concise description
 	; Elite Enchantment Spell. Steal 5...41...50 Health from target foe. You have +5...9...10 Health regeneration (10 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 823 - $GC_I_SKILL_ID_BURNING_SPEED
@@ -1406,7 +1484,9 @@ Func BestTarget_BorrowedEnergy($a_f_AggroRange)
 	; Mesmer
 	; Concise description
 	; green; font-weight: bold;">4...9...10
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 837 - $GC_I_SKILL_ID_ENERGY_BOON
@@ -1420,7 +1500,9 @@ Func BestTarget_EnergyBoon($a_f_AggroRange)
 	; Elite Enchantment Spell. For 36...55...60 seconds, Energy Boon raises the maximum Health of you and target ally by 1...3...3 for each point of your respective maximum Energy. When this enchantment is first applied, you and your target gain 1...10...12 Energy. You gain an additional 1 Energy for every 2 points you have in Energy Storage.
 	; Concise description
 	; Elite Enchantment Spell. (36...55...60 seconds.) Maximum Health for you and target ally is increased by 1...3...3 for each point of maximum Energy. Initial effect: Both gain 1...10...12 Energy. You gain +1 Energy for every 2 points of Energy Storage.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 838 - $GC_I_SKILL_ID_DWAYNAS_SORROW
@@ -1430,7 +1512,8 @@ Func CanUse_DwaynasSorrow()
 EndFunc
 
 Func BestTarget_DwaynasSorrow($a_f_AggroRange)
-	Return 0
+	; Dwayna's Sorrow is a self-targeted enchantment
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 843 - $GC_I_SKILL_ID_GUST
@@ -1444,7 +1527,9 @@ Func BestTarget_Gust($a_f_AggroRange)
 	; Elite Enchantment Spell. For 5...10...11 seconds, both you and target ally move 33% faster. When you cast this spell, all foes near you and your target take 15...59...70 cold damage. Foes struck by Gust while attacking or moving are knocked down.
 	; Concise description
 	; Elite Enchantment Spell. (5...10...11 seconds.) You and target ally move 33% faster. Initial effect: Foes near you and target ally are struck for 15...59...70 cold damage. Attacking or moving foes are knocked down.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 848 - $GC_I_SKILL_ID_REVERSE_HEX
@@ -1458,7 +1543,12 @@ Func BestTarget_ReverseHex($a_f_AggroRange)
 	; Enchantment Spell. Remove one hex from target ally. If a hex was removed in this way, for 5...9...10 seconds, the next time target ally would take damage, that damage is reduced by 5...41...50.
 	; Concise description
 	; Enchantment Spell. (5...9...10 seconds.) Removes one hex from target ally. The next damage this ally takes is reduced by 5...41...50. No effect unless this ally is hexed.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	
+	$l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 863 - $GC_I_SKILL_ID_ORDER_OF_APOSTASY
@@ -1500,7 +1590,9 @@ Func BestTarget_RestfulBreeze($a_f_AggroRange)
 	; Enchantment Spell. For 8...16...18 seconds, target ally has +10 Health regeneration. This enchantment ends if that ally attacks or uses a skill.
 	; Concise description
 	; Enchantment Spell. (8...16...18 seconds.) +10 Health regeneration. Ends if target ally attacks or uses a skill.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 925 - $GC_I_SKILL_ID_RECALL
@@ -1514,7 +1606,9 @@ Func BestTarget_Recall($a_f_AggroRange)
 	; Enchantment Spell. While you maintain Recall, nothing happens. When Recall ends, you Shadow Step to the ally you targeted when you activated this skill and all of your skills are disabled for 10 seconds.
 	; Concise description
 	; Enchantment Spell. End effect: Shadow Step to target ally. Cannot self-target and disables all of your skills for 10 seconds when it ends.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 926 - $GC_I_SKILL_ID_SHARPEN_DAGGERS
@@ -1654,7 +1748,7 @@ Func BestTarget_IceBreaker($a_f_AggroRange)
 	; This article is about the snow fighting skill. For the unique hammer, see The Ice Breaker.
 	; Concise description
 	; Acquisition">edit
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1027 - $GC_I_SKILL_ID_CRITICAL_DEFENSES
@@ -1730,7 +1824,8 @@ Func CanUse_AncestorsVisage()
 EndFunc
 
 Func BestTarget_AncestorsVisage($a_f_AggroRange)
-	Return 0
+	; Ancestors Visage is a self-targeted enchantment
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1084 - $GC_I_SKILL_ID_SLIVER_ARMOR
@@ -1758,7 +1853,9 @@ Func BestTarget_DoubleDragon($a_f_AggroRange)
 	; Elite Enchantment Spell. Invoke the power of the Dragon. For 8 seconds, you and target ally are enchanted with Double Dragon. Adjacent foes are dealt 5...25...30 fire damage each second. Additionally, when you or your ally use skills that target a foe, that foe is set on fire for 0...2...3 second[s].
 	; Concise description
 	; Elite Enchantment Spell. (8 seconds.) Enchants you and target ally. Adjacent foes take 5...25...30 fire damage each second. Skills that target a foe also inflict Burning (0...2...3 second[s]).
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1114 - $GC_I_SKILL_ID_SPIRIT_BOND
@@ -1772,7 +1869,9 @@ Func BestTarget_SpiritBond($a_f_AggroRange)
 	; Enchantment Spell. For 8 seconds, whenever target ally takes more than 50 damage from the next 10 attacks or spells, that ally is healed for 30...78...90 Health.
 	; Concise description
 	; Enchantment Spell. (8 seconds.) Heals for 30...78...90 whenever target ally takes more than 50 damage. Ends after this ally takes damage from 10 attacks or spells.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1115 - $GC_I_SKILL_ID_AIR_OF_ENCHANTMENT
@@ -1786,7 +1885,9 @@ Func BestTarget_AirOfEnchantment($a_f_AggroRange)
 	; Elite Enchantment Spell. For 4...9...10 seconds, enchantments cast on target other ally cost 5 less Energy (minimum 1 Energy).
 	; Concise description
 	; Elite Enchantment Spell. (4...9...10 seconds.) Enchantments cast on target ally cost 5 less Energy (minimum 1 Energy). Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1123 - $GC_I_SKILL_ID_LIFE_SHEATH
@@ -1800,7 +1901,12 @@ Func BestTarget_LifeSheath($a_f_AggroRange)
 	; Elite Enchantment Spell. Remove 0...2...2 condition[s] from target ally. For 8 seconds, the next time that ally would take damage or life steal, that ally gains that amount of Health instead (maximum 20...84...100).
 	; Concise description
 	; Elite Enchantment Spell. (8 seconds.) Converts the next incoming damage or life steal (maximum 20...84...100) to healing. Initial effect: Removes 0...2...2 condition[s].
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	
+	$l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1152 - $GC_I_SKILL_ID_DEMONIC_AGILITY
@@ -1964,7 +2070,7 @@ Func BestTarget_JaggedBones($a_f_AggroRange)
 	; Elite Enchantment Spell. For 30 seconds, whenever target undead servant dies, it is replaced by a level 0...12...15 jagged horror that causes Bleeding with each of its attacks.
 	; Concise description
 	; Elite Enchantment Spell. (30 seconds.) When target undead servant dies, it is replaced by a level 0...12...15 jagged horror that inflicts Bleeding with attacks.
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1356 - $GC_I_SKILL_ID_CONTAGION
@@ -2030,7 +2136,9 @@ Func BestTarget_StoneSheath($a_f_AggroRange)
 	; Elite Enchantment Spell. For 5...17...20 seconds, you and target ally have +1...24...30 armor and are immune to critical hits. When you cast this spell, all foes near you and your target take 15...59...70 earth damage and are Weakened for 5...17...20 seconds.
 	; Concise description
 	; Elite Enchantment Spell. (5...17...20 seconds.) Gives you and target ally +1...24...30 armor and immunity to critical hits. Initial effect: Foes near you and target ally are struck for 15...59...70 earth damage and are Weakened (5...17...20 seconds).
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1375 - $GC_I_SKILL_ID_STONEFLESH_AURA
@@ -2082,7 +2190,9 @@ Func BestTarget_JudgesIntervention($a_f_AggroRange)
 	; Enchantment Spell. For 10 seconds, the next time target ally receives damage that would be fatal, the damage is negated and one nearby foe takes 30...150...180 holy damage.
 	; Concise description
 	; Enchantment Spell. (10 seconds.) Negates the next fatal damage. Negation effect: deals 30...150...180 holy damage to one foe near target ally.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1391 - $GC_I_SKILL_ID_SUPPORTIVE_SPIRIT
@@ -2096,7 +2206,9 @@ Func BestTarget_SupportiveSpirit($a_f_AggroRange)
 	; Enchantment Spell. For 5...19...23 seconds, whenever target ally takes damage while knocked down, that ally is healed for 5...29...35 Health.
 	; Concise description
 	; Enchantment Spell. (5...19...23 seconds.) Heals for 5...29...35 whenever target ally takes damage while knocked-down.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1392 - $GC_I_SKILL_ID_WATCHFUL_HEALING
@@ -2110,7 +2222,9 @@ Func BestTarget_WatchfulHealing($a_f_AggroRange)
 	; Enchantment Spell. For 10 seconds, target ally gains +1...3...4 Health regeneration. If this skill ends prematurely, that ally gains 30...102...120 Health.
 	; Concise description
 	; Enchantment Spell. (10 seconds.) Target ally has +1...3...4 Health regeneration and gains 30...102...120 Health if this enchantment ends early.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1393 - $GC_I_SKILL_ID_HEALERS_BOON
@@ -2144,7 +2258,8 @@ Func CanUse_BalthazarsPendulum()
 EndFunc
 
 Func BestTarget_BalthazarsPendulum($a_f_AggroRange)
-	Return 0
+	; Balthazar's Pendulum is a self-targeted enchantment
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1399 - $GC_I_SKILL_ID_SHIELD_OF_ABSORPTION
@@ -2158,7 +2273,9 @@ Func BestTarget_ShieldOfAbsorption($a_f_AggroRange)
 	; Enchantment Spell. For 3...6...7 seconds, damage received by target ally is reduced by 5 each time that ally is hit while under the effects of this enchantment.
 	; Concise description
 	; Enchantment Spell. (3...6...7 seconds.) Reduces incoming damage by 5 each time target ally takes damage.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1400 - $GC_I_SKILL_ID_REVERSAL_OF_DAMAGE
@@ -2172,7 +2289,9 @@ Func BestTarget_ReversalOfDamage($a_f_AggroRange)
 	; Enchantment Spell. For 8 seconds, the next time target ally would take damage, the foe dealing the damage takes that damage instead (maximum 5...61...75).
 	; Concise description
 	; Enchantment Spell. (8 seconds.) Negates the next damage and hits the source for that same amount (maximum 5...61...75).
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1450 - $GC_I_SKILL_ID_ABADDONS_CONSPIRACY
@@ -2182,7 +2301,8 @@ Func CanUse_AbaddonsConspiracy()
 EndFunc
 
 Func BestTarget_AbaddonsConspiracy($a_f_AggroRange)
-	Return 0
+	; Abaddon's Conspiracy is a self-targeted enchantment
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1457 - $GC_I_SKILL_ID_ABADDONS_CHOSEN
@@ -2365,7 +2485,9 @@ Func BestTarget_WatchfulIntervention($a_f_AggroRange)
 	; Enchantment Spell. For 60 seconds, the next time damage drops target ally's Health below 25%, that ally is healed for 50...170...200 Health.
 	; Concise description
 	; Enchantment Spell. (60 seconds.) Heals for 50...170...200 the next time damage drops target ally's Health below 25%.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1505 - $GC_I_SKILL_ID_VOW_OF_PIETY
@@ -2427,7 +2549,6 @@ EndFunc
 ; Skill ID: 1510 - $GC_I_SKILL_ID_SAND_SHARDS
 Func CanUse_SandShards()
 	If Anti_Enchantment() Then Return False
-	If UAI_PlayerHasEffect($GC_I_SKILL_ID_SAND_SHARDS) Then Return False
 	If UAI_CountAgents(-2, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy") <= 1 Then Return False
 	Return True
 EndFunc
@@ -2686,7 +2807,9 @@ Func BestTarget_ShadowMeld($a_f_AggroRange)
 	; Elite Enchantment Spell. Shadow Step to target other ally. When you stop maintaining this Enchantment, you return to your original location.
 	; Concise description
 	; Elite Enchantment Spell. Shadow Step to target ally. End effect: return to your original location. Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1663 - $GC_I_SKILL_ID_ELEMENTAL_FLAME
@@ -2714,7 +2837,9 @@ Func BestTarget_PensiveGuardian($a_f_AggroRange)
 	; Enchantment Spell. For 5...10...11 seconds, target ally has a 50% chance to block attacks from enchanted foes.
 	; Concise description
 	; Enchantment Spell. (5...10...11 seconds.) 50% chance to block enchanted foes.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1684 - $GC_I_SKILL_ID_SCRIBES_INSIGHT
@@ -2864,11 +2989,14 @@ EndFunc
 ; Skill ID: 1759 - $GC_I_SKILL_ID_VOW_OF_STRENGTH
 Func CanUse_VowOfStrength()
 	If Anti_Enchantment() Then Return False
-	If UAI_PlayerHasEffect($GC_I_SKILL_ID_VOW_OF_STRENGTH) Then Return False
-	; If Extend Enchantments is in the bar and not currently active, wait for it (it will cast first via slot order)
-	Local $l_i_ExtendSlot = Skill_GetSlotByID($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS)
-	If $l_i_ExtendSlot > 0 Then
-		If Not UAI_PlayerHasEffect($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS) Then Return False
+
+	Local $l_b_SkillSlot = Skill_GetSlotByID($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS)
+	Local $l_b_HasEffect = UAI_GetPlayerEffectInfo($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS, $GC_UAI_EFFECT_TimeRemaining) > 500
+
+	If $l_b_SkillSlot > 0 Then
+		If Not $l_b_HasEffect Then
+			Skill_UseSkill($l_b_SkillSlot)
+		EndIf
 	EndIf
 	Return True
 EndFunc
@@ -3101,7 +3229,9 @@ Func BestTarget_WitheringAura($a_f_AggroRange)
 	; Enchantment Spell. For 5...17...20 seconds, target ally's melee attacks cause Weakness for 5...17...20 seconds.
 	; Concise description
 	; Enchantment Spell. (5...17...20 seconds.) Target ally's melee attacks cause Weakness condition (5...17...20 seconds.)
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2005 - $GC_I_SKILL_ID_SMITERS_BOON
@@ -3125,7 +3255,12 @@ Func BestTarget_PurifyingVeil($a_f_AggroRange)
 	; Enchantment Spell. While you maintain this enchantment, conditions expire 5...41...50% faster on target ally. When this enchantment ends, one condition is removed from that ally.
 	; Concise description
 	; Enchantment Spell. Conditions expire 5...41...50% faster on target ally. End effect: removes a condition.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	
+	$l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2013 - $GC_I_SKILL_ID_GRENTHS_AURA
@@ -3151,7 +3286,9 @@ Func BestTarget_PatientSpirit($a_f_AggroRange)
 	; Enchantment Spell. For 2 seconds, target ally is enchanted with Patient Spirit. Unless this enchantment ends prematurely, that ally is healed for 30...102...120 Health when the enchantment ends.
 	; Concise description
 	; Enchantment Spell. (2 seconds.) End effect: heals for 30...102...120. No effect if ends early.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2063 - $GC_I_SKILL_ID_AURA_OF_STABILITY
@@ -3165,7 +3302,9 @@ Func BestTarget_AuraOfStability($a_f_AggroRange)
 	; Enchantment Spell. For 3...7...8 seconds, target other ally cannot be knocked down.
 	; Concise description
 	; Enchantment Spell. (3...7...8 seconds.) Target ally cannot be knocked-down. Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2064 - $GC_I_SKILL_ID_SPOTLESS_MIND
@@ -3179,7 +3318,12 @@ Func BestTarget_SpotlessMind($a_f_AggroRange)
 	; Enchantment Spell. For 1...12...15 seconds, target other ally loses a hex every 5 seconds.
 	; Concise description
 	; Enchantment Spell. (1...12...15 seconds.) Removes a hex every 5 seconds. Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	
+	$l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2065 - $GC_I_SKILL_ID_SPOTLESS_SOUL
@@ -3193,7 +3337,12 @@ Func BestTarget_SpotlessSoul($a_f_AggroRange)
 	; Enchantment Spell. For 1...12...15 seconds, target other ally loses a condition every 3 seconds.
 	; Concise description
 	; Enchantment Spell. (1...12...15 seconds.) Removes a condition every 3 seconds. Cannot self-target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	
+	$l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2091 - $GC_I_SKILL_ID_SHADOW_SANCTUARY_KURZICK
@@ -3262,7 +3411,9 @@ Func BestTarget_SeedOfLife($a_f_AggroRange)
 	; Enchantment Spell. For 2...5 seconds, whenever target other ally takes damage, all party members are healed for 2 Health for each rank in Divine Favor.
 	; Concise description
 	; Enchantment Spell. (2...5) seconds. Heals party members for 2 for each rank in Divine Favor whenever target takes damage. Cannot self target.
-	Return 0
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2109 - $GC_I_SKILL_ID_ETERNAL_AURA
@@ -3340,7 +3491,7 @@ Func BestTarget_MagneticSurge($a_f_AggroRange)
 	; Enchantment Spell. Target foe takes 15...63...75 damage. If you are Overcast, Magnetic Surge enchants all allies in earshot for 1...4...5 second[s] to block the next attack against them.
 	; Concise description
 	; Enchantment Spell. Deals 15...63...75 damage. If you are Overcast, allies in earshot are enchanted for 1...4...5 [sic] and block the next attack against them.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2201 - $GC_I_SKILL_ID_SHIELD_OF_FORCE
@@ -3368,7 +3519,9 @@ Func BestTarget_GreatDwarfArmor($a_f_AggroRange)
 	; Enchantment Spell. For 22...40 seconds, target ally has +24 armor, +60 maximum Health, and an additional +24 armor against Destroyers.
 	; Concise description
 	; Enchantment Spell. (22...40 seconds.) +24 armor and +60 maximum Health. Additional +24 armor against Destroyers.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2249 - $GC_I_SKILL_ID_POLYMOCK_BLOCK
@@ -3537,7 +3690,8 @@ Func CanUse_AegisPvP()
 EndFunc
 
 Func BestTarget_AegisPvP($a_f_AggroRange)
-	Return 0
+	; Aegis PvP is a self-targeted enchantment
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2860 - $GC_I_SKILL_ID_ETHER_RENEWAL_PvP
@@ -3587,7 +3741,8 @@ Func CanUse_UnyieldingAuraPvP()
 EndFunc
 
 Func BestTarget_UnyieldingAuraPvP($a_f_AggroRange)
-	Return 0
+	; Unyielding Aura PvP is a self-targeted enchantment
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2892 - $GC_I_SKILL_ID_SPIRIT_BOND_PvP
@@ -3597,7 +3752,10 @@ Func CanUse_SpiritBondPvP()
 EndFunc
 
 Func BestTarget_SpiritBondPvP($a_f_AggroRange)
-	Return 0
+	; Spirit Bond PvP targets lowest HP ally
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2895 - $GC_I_SKILL_ID_SMITERS_BOON_PvP
@@ -3621,7 +3779,7 @@ Func BestTarget_BitGolemRectifier($a_f_AggroRange)
 	; Enchantment Spell. N.O.X. is healed for 10 Health every second.
 	; Concise description
 	; Enchantment Spell. Heals N.O.X. for 10 every second.
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2915 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -3635,7 +3793,8 @@ Func CanUse_StrengthOfHonorPvP()
 EndFunc
 
 Func BestTarget_StrengthOfHonorPvP($a_f_AggroRange)
-	Return 0
+	; Strength of Honor PvP is a self-targeted enchantment
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 3003 - $GC_I_SKILL_ID_ARMOR_OF_UNFEELING_PvP

--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Hex.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Hex.au3
@@ -52,7 +52,7 @@ Func BestTarget_Fragility($a_f_AggroRange)
 	; Hex Spell. Also hexes foes adjacent to target (8...18...20 seconds). These foes take 5...17...20 damage each time they gain or lose a condition.
 	; Concise description
 	; Spell. Also hexes foes adjacent to target (8...18...20 seconds). These foes take 5...17...20 damage each time they gain or lose a condition.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 20 - $GC_I_SKILL_ID_CONFUSION
@@ -66,7 +66,7 @@ Func BestTarget_Confusion($a_f_AggroRange)
 	; Hex Spell. (8...18...21 seconds.) Target foe's attacks may damage any character in range, including the target.
 	; Concise description
 	; Spell. (8...18...21 seconds.) Target foe's attacks may damage any character in range, including the target.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 26 - $GC_I_SKILL_ID_EMPATHY
@@ -111,7 +111,7 @@ Func BestTarget_Diversion($a_f_AggroRange)
 	; Hex Spell. (6 seconds.) Target foe's next skill takes +10...47...56 seconds to recharge.
 	; Concise description
 	; Spell. (6 seconds.) Target foe's next skill takes +10...47...56 seconds to recharge.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 31 - $GC_I_SKILL_ID_CONJURE_PHANTASM
@@ -139,7 +139,7 @@ Func BestTarget_Ignorance($a_f_AggroRange)
 	; Hex Spell. (8...18...20 seconds.) Target foe cannot use signets.
 	; Concise description
 	; Spell. (8...18...20 seconds.) Target foe cannot use signets.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 36 - $GC_I_SKILL_ID_ARCANE_CONUNDRUM
@@ -149,7 +149,7 @@ Func CanUse_ArcaneConundrum()
 EndFunc
 
 Func BestTarget_ArcaneConundrum($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 41 - $GC_I_SKILL_ID_ETHER_LORD
@@ -163,7 +163,7 @@ Func BestTarget_EtherLord($a_f_AggroRange)
 	; Hex Spell. You lose all Energy. Target foe has -1...3...3 Energy degeneration and you have +1...3...3 Energy regeneration (5...9...10 seconds).
 	; Concise description
 	; Spell. You lose all Energy. Target foe has -1...3...3 Energy degeneration and you have +1...3...3 Energy regeneration (5...9...10 seconds).
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 43 - $GC_I_SKILL_ID_CLUMSINESS
@@ -191,7 +191,7 @@ Func BestTarget_PhantomPain($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) Causes -1...3...4 Health degeneration. End effect: inflicts Deep Wound condition (5...17...20 seconds).
 	; Concise description
 	; Spell. (10 seconds.) Causes -1...3...4 Health degeneration. End effect: inflicts Deep Wound condition (5...17...20 seconds).
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 45 - $GC_I_SKILL_ID_ETHEREAL_BURDEN
@@ -205,7 +205,9 @@ Func BestTarget_EtherealBurden($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) Target foe moves 50% slower. End effect: you gain 10...16...18 Energy.
 	; Concise description
 	; Spell. (10 seconds.) Target foe moves 50% slower. End effect: you gain 10...16...18 Energy.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 46 - $GC_I_SKILL_ID_GUILT
@@ -219,7 +221,7 @@ Func BestTarget_Guilt($a_f_AggroRange)
 	; Hex Spell. (6 seconds.) Target foe's next spell fails and you steal 5...12...14 Energy. No effect unless this foe's spell targets one of your allies.
 	; Concise description
 	; Spell. (6 seconds.) Target foe's next spell fails and you steal 5...12...14 Energy. No effect unless this foe's spell targets one of your allies.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 47 - $GC_I_SKILL_ID_INEPTITUDE
@@ -247,7 +249,7 @@ Func BestTarget_SpiritOfFailure($a_f_AggroRange)
 	; Hex Spell. (30 seconds.) Target foe has 25% chance to miss. You gain 1...3...3 Energy whenever this foe misses.
 	; Concise description
 	; Spell. (30 seconds.) Target foe has 25% chance to miss. You gain 1...3...3 Energy whenever this foe misses.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 49 - $GC_I_SKILL_ID_MIND_WRACK
@@ -261,7 +263,7 @@ Func BestTarget_MindWrack($a_f_AggroRange)
 	; Hex Spell. (5...33...40 seconds.) Causes 1 Energy loss each time foe is the target of your non-hex Mesmer skills. Deals 5...21...25 damage per point of Energy lost. If target foe's Energy drops to 0, it takes 15...83...100 damage and Mind Wrack ends.
 	; Concise description
 	; Spell. (5...33...40 seconds.) Causes 1 Energy loss each time foe is the target of your non-hex Mesmer skills. Deals 5...21...25 damage per point of Energy lost. If target foe's Energy drops to 0, it takes 15...83...100 damage and Mind Wrack ends.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 50 - $GC_I_SKILL_ID_WASTRELS_WORRY
@@ -275,7 +277,7 @@ Func BestTarget_WastrelsWorry($a_f_AggroRange)
 	; Hex Spell. (3 seconds). End effect: causes 20...84...100 damage to target and adjacent foes. No effect and ends early if target foe uses a skill.
 	; Concise description
 	; Spell. (3 seconds). End effect: causes 20...84...100 damage to target and adjacent foes. No effect and ends early if target foe uses a skill.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 51 - $GC_I_SKILL_ID_SHAME
@@ -289,7 +291,7 @@ Func BestTarget_Shame($a_f_AggroRange)
 	; Hex Spell. (6 seconds.) Target foe's next spell fails and you steal 5...12...14 Energy. No effect unless this foe's spell targeted one of its allies.
 	; Concise description
 	; Spell. (6 seconds.) Target foe's next spell fails and you steal 5...12...14 Energy. No effect unless this foe's spell targeted one of its allies.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 52 - $GC_I_SKILL_ID_PANIC
@@ -303,7 +305,7 @@ Func BestTarget_Panic($a_f_AggroRange)
 	; Elite Hex Spell. Also hexes foes near your target (1...8...10 second[s]). Interrupts all other nearby foes whenever a hexed foe successfully activates a skill.
 	; Concise description
 	; Hex Spell. Also hexes foes near your target (1...8...10 second[s]). Interrupts all other nearby foes whenever a hexed foe successfully activates a skill.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 53 - $GC_I_SKILL_ID_MIGRAINE
@@ -317,7 +319,7 @@ Func BestTarget_Migraine($a_f_AggroRange)
 	; Elite Hex Spell. (5...17...20 seconds.) Causes -1...7...8 Health degeneration and doubles skill activation time.
 	; Concise description
 	; Hex Spell. (5...17...20 seconds.) Causes -1...7...8 Health degeneration and doubles skill activation time.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 54 - $GC_I_SKILL_ID_CRIPPLING_ANGUISH
@@ -331,7 +333,9 @@ Func BestTarget_CripplingAnguish($a_f_AggroRange)
 	; Elite Hex Spell. (5...17...20 seconds.) Target foe moves and attacks 50% slower and has -1...7...8 Health degeneration.
 	; Concise description
 	; Hex Spell. (5...17...20 seconds.) Target foe moves and attacks 50% slower and has -1...7...8 Health degeneration.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 55 - $GC_I_SKILL_ID_FEVERED_DREAMS
@@ -345,7 +349,7 @@ Func BestTarget_FeveredDreams($a_f_AggroRange)
 	; Elite Hex Spell. (10...22...25 seconds.) Foes in the area also have any new conditions that target foe acquires. Inflicts Dazed on target foe (1...3...3 second[s]) if that foe has two or more conditions.
 	; Concise description
 	; Hex Spell. (10...22...25 seconds.) Foes in the area also have any new conditions that target foe acquires. Inflicts Dazed on target foe (1...3...3 second[s]) if that foe has two or more conditions.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 56 - $GC_I_SKILL_ID_SOOTHING_IMAGES
@@ -359,7 +363,7 @@ Func BestTarget_SoothingImages($a_f_AggroRange)
 	; Hex Spell. Also hexes foe adjacent to target. (8...18...20 seconds). These foes cannot gain adrenaline.
 	; Concise description
 	; Spell. Also hexes foe adjacent to target. (8...18...20 seconds). These foes cannot gain adrenaline.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 66 - $GC_I_SKILL_ID_SPIRIT_SHACKLES
@@ -373,7 +377,7 @@ Func BestTarget_SpiritShackles($a_f_AggroRange)
 	; Hex Spell. (5...17...20). Target foe loses 5 Energy whenever it attacks.
 	; Concise description
 	; Spell. (5...17...20). Target foe loses 5 Energy whenever it attacks.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 76 - $GC_I_SKILL_ID_IMAGINED_BURDEN
@@ -432,7 +436,10 @@ Func BestTarget_Barbs($a_f_AggroRange)
 	; Hex Spell. (30 seconds.) Target foe takes 1...12...15 damage whenever it takes physical damage.
 	; Concise description
 	; Spell. (30 seconds.) Target foe takes 1...12...15 damage whenever it takes physical damage.
-	Return 0
+	; Target attacking enemies for maximum effect
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 103 - $GC_I_SKILL_ID_PRICE_OF_FAILURE
@@ -442,7 +449,11 @@ Func CanUse_PriceOfFailure()
 EndFunc
 
 Func BestTarget_PriceOfFailure($a_f_AggroRange)
-	Return 0
+	; Description
+	; Hex Spell. (20 seconds.) Also hexes nearby foes. The next skill used by target foes cost 25 Energy and recharges in 90 seconds.
+	; Concise description
+	; Spell. (20 seconds.) Also hexes nearby foes. The next skill used by target foes cost 25 Energy and recharges in 90 seconds.
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 108 - $GC_I_SKILL_ID_SUFFERING
@@ -456,7 +467,7 @@ Func BestTarget_Suffering($a_f_AggroRange)
 	; Hex Spell. Also hexes foes near target (6...25...30 seconds). These foes have -0...2...3 Health degeneration.
 	; Concise description
 	; Spell. Also hexes foes near target (6...25...30 seconds). These foes have -0...2...3 Health degeneration.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 109 - $GC_I_SKILL_ID_LIFE_SIPHON
@@ -484,7 +495,7 @@ Func BestTarget_SpitefulSpirit($a_f_AggroRange)
 	; Elite Hex Spell. (8...18...20 seconds.) Deals 5...29...35 damage to target and adjacent foes whenever this foe attacks or uses a skill.
 	; Concise description
 	; Hex Spell. (8...18...20 seconds.) Deals 5...29...35 damage to target and adjacent foes whenever this foe attacks or uses a skill.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 122 - $GC_I_SKILL_ID_MALIGN_INTERVENTION
@@ -498,7 +509,7 @@ Func BestTarget_MalignIntervention($a_f_AggroRange)
 	; Hex Spell. (5...17...20 seconds.) Target foe receives 20% less from healing. If this foe dies while suffering from this hex, a level 1...14...17 masterless bone horror is summoned.
 	; Concise description
 	; Spell. (5...17...20 seconds.) Target foe receives 20% less from healing. If this foe dies while suffering from this hex, a level 1...14...17 masterless bone horror is summoned.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 123 - $GC_I_SKILL_ID_INSIDIOUS_PARASITE
@@ -512,7 +523,7 @@ Func BestTarget_InsidiousParasite($a_f_AggroRange)
 	; Hex Spell. (5...13...15 seconds.) Steal 15...39...45 Health whenever target foe hits with an attack.
 	; Concise description
 	; Spell. (5...13...15 seconds.) Steal 15...39...45 Health whenever target foe hits with an attack.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 124 - $GC_I_SKILL_ID_SPINAL_SHIVERS
@@ -522,7 +533,7 @@ Func CanUse_SpinalShivers()
 EndFunc
 
 Func BestTarget_SpinalShivers($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 125 - $GC_I_SKILL_ID_WITHER
@@ -536,7 +547,7 @@ Func BestTarget_Wither($a_f_AggroRange)
 	; Elite Hex Spell. (5...29...35 seconds.) Causes -2...4...4 Health degeneration and -1 Energy degeneration. Deals 15...63...75 damage if target foe's Energy drops to 0. Ends if this foe's Energy drops to 0.
 	; Concise description
 	; Hex Spell. (5...29...35 seconds.) Causes -2...4...4 Health degeneration and -1 Energy degeneration. Deals 15...63...75 damage if target foe's Energy drops to 0. Ends if this foe's Energy drops to 0.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 126 - $GC_I_SKILL_ID_LIFE_TRANSFER
@@ -550,7 +561,7 @@ Func BestTarget_LifeTransfer($a_f_AggroRange)
 	; Elite Hex Spell. Also hexes foes adjacent to target (6...11...12 second). Causes -3...7...8 Health degeneration. You have +3...7...8 Health regeneration.
 	; Concise description
 	; Hex Spell. Also hexes foes adjacent to target (6...11...12 second). Causes -3...7...8 Health degeneration. You have +3...7...8 Health regeneration.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 127 - $GC_I_SKILL_ID_MARK_OF_SUBVERSION
@@ -564,7 +575,7 @@ Func BestTarget_MarkOfSubversion($a_f_AggroRange)
 	; Hex Spell. (6 seconds.) Target foe's next spell fails and you steal 10...76...92 Health. No effect unless this foe's spell targeted one of its allies.
 	; Concise description
 	; Spell. (6 seconds.) Target foe's next spell fails and you steal 10...76...92 Health. No effect unless this foe's spell targeted one of its allies.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 128 - $GC_I_SKILL_ID_SOUL_LEECH
@@ -578,7 +589,7 @@ Func BestTarget_SoulLeech($a_f_AggroRange)
 	; Elite Hex Spell. (10 seconds.) Steal 16...67...80 Health whenever target foe casts a spell.
 	; Concise description
 	; Hex Spell. (10 seconds.) Steal 16...67...80 Health whenever target foe casts a spell.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 129 - $GC_I_SKILL_ID_DEFILE_FLESH
@@ -592,7 +603,7 @@ Func BestTarget_DefileFlesh($a_f_AggroRange)
 	; Hex Spell. (5...29...35 seconds.) Reduces healing target foe receives by 33%. Only skills with the word "heal" in the description are affected.
 	; Concise description
 	; Spell. (5...29...35 seconds.) Reduces healing target foe receives by 33%. Only skills with the word "heal" in the description are affected.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 135 - $GC_I_SKILL_ID_FAINTHEARTEDNESS
@@ -623,7 +634,7 @@ Func BestTarget_ShadowOfFear($a_f_AggroRange)
 	; Hex Spell. Also hexes foes adjacent to target (5...25...30 seconds). They attack 50% slower.
 	; Concise description
 	; Spell. Also hexes foes adjacent to target (5...25...30 seconds). They attack 50% slower.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 137 - $GC_I_SKILL_ID_RIGOR_MORTIS
@@ -637,7 +648,7 @@ Func BestTarget_RigorMortis($a_f_AggroRange)
 	; Hex Spell. (8...18...20 seconds.) Target foe cannot block.
 	; Concise description
 	; Spell. (8...18...20 seconds.) Target foe cannot block.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 140 - $GC_I_SKILL_ID_MALAISE
@@ -651,7 +662,7 @@ Func BestTarget_Malaise($a_f_AggroRange)
 	; Hex Spell. (5...29...35 seconds.) Causes -1 Energy degeneration. Deals 5...41...50 damage if target foe's Energy drops to 0. You have -1 Health degeneration. Ends if this foe's Energy drops to 0.
 	; Concise description
 	; Spell. (5...29...35 seconds.) Causes -1 Energy degeneration. Deals 5...41...50 damage if target foe's Energy drops to 0. You have -1 Health degeneration. Ends if this foe's Energy drops to 0.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 142 - $GC_I_SKILL_ID_LINGERING_CURSE
@@ -665,7 +676,7 @@ Func BestTarget_LingeringCurse($a_f_AggroRange)
 	; Elite Hex Spell. (6...25...30 seconds.) Target and nearby foes have -0...2...3 Health degeneration and receive 20% less benefit from healing.
 	; Concise description
 	; Hex Spell. (6...25...30 seconds.) Target and nearby foes have -0...2...3 Health degeneration and receive 20% less benefit from healing.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 150 - $GC_I_SKILL_ID_MARK_OF_PAIN
@@ -679,7 +690,7 @@ Func BestTarget_MarkOfPain($a_f_AggroRange)
 	; Hex Spell. (30 seconds.) Deals 10...34...40 damage to adjacent foes whenever target foe takes physical damage.
 	; Concise description
 	; Spell. (30 seconds.) Deals 10...34...40 damage to adjacent foes whenever target foe takes physical damage.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 173 - $GC_I_SKILL_ID_GRASPING_EARTH
@@ -707,7 +718,7 @@ Func BestTarget_IncendiaryBonds($a_f_AggroRange)
 	; Hex Spell. (3 seconds.) End effect: deals 20...68...80 fire damage and inflicts Burning condition (1...3...3 second[s]) to foes near your target. Also triggers if foe dies.
 	; Concise description
 	; Spell. (3 seconds.) End effect: deals 20...68...80 fire damage and inflicts Burning condition (1...3...3 second[s]) to foes near your target. Also triggers if foe dies.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 190 - $GC_I_SKILL_ID_MARK_OF_RODGORT
@@ -721,7 +732,7 @@ Func BestTarget_MarkOfRodgort($a_f_AggroRange)
 	; Hex Spell. Also hexes foes near your target (10...30...35 seconds). Inflicts Burning condition (1...3...4 second[s]) when these foes take fire damage.
 	; Concise description
 	; Spell. Also hexes foes near your target (10...30...35 seconds). Inflicts Burning condition (1...3...4 second[s]) when these foes take fire damage.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 204 - $GC_I_SKILL_ID_RUST
@@ -735,7 +746,7 @@ Func BestTarget_Rust($a_f_AggroRange)
 	; Hex Spell. Deals 10...58...70 cold damage to target and adjacent foes. Hexes target and adjacent foes (5...17...20 seconds). Doubles signet activation time. Interrupts and disables signets for 1...8...10 second[s] if you are Overcast.
 	; Concise description
 	; Spell. Deals 10...58...70 cold damage to target and adjacent foes. Hexes target and adjacent foes (5...17...20 seconds). Doubles signet activation time. Interrupts and disables signets for 1...8...10 second[s] if you are Overcast.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 205 - $GC_I_SKILL_ID_LIGHTNING_SURGE
@@ -749,7 +760,7 @@ Func BestTarget_LightningSurge($a_f_AggroRange)
 	; Elite Hex Spell. (3 seconds.) End effect: deals 14...83...100 lightning damage, causes knock-down, and inflicts Cracked Armor (5...17...20 seconds). 25% armor penetration.
 	; Concise description
 	; Hex Spell. (3 seconds.) End effect: deals 14...83...100 lightning damage, causes knock-down, and inflicts Cracked Armor (5...17...20 seconds). 25% armor penetration.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 209 - $GC_I_SKILL_ID_MIND_FREEZE
@@ -763,7 +774,7 @@ Func BestTarget_MindFreeze($a_f_AggroRange)
 	; Elite Hex Spell. Deals 10...50...60 cold damage. If you have more Energy than target foe, deals +10...50...60 cold damage and causes 90% slower movement (1...4...5 second[s]).
 	; Concise description
 	; Hex Spell. Deals 10...50...60 cold damage. If you have more Energy than target foe, deals +10...50...60 cold damage and causes 90% slower movement (1...4...5 second[s]).
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 210 - $GC_I_SKILL_ID_ICE_PRISON
@@ -777,7 +788,9 @@ Func BestTarget_IcePrison($a_f_AggroRange)
 	; Hex Spell. (8...18...20 seconds.) Target foe moves 66% slower.
 	; Concise description
 	; Spell. (8...18...20 seconds.) Target foe moves 66% slower.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 211 - $GC_I_SKILL_ID_ICE_SPIKES
@@ -791,7 +804,7 @@ Func BestTarget_IceSpikes($a_f_AggroRange)
 	; Hex Spell. Also hexes foes adjacent to target (2...5...6 seconds). These foes move 66% slower. Initial effect: deals 20...68...80 cold damage.
 	; Concise description
 	; Spell. Also hexes foes adjacent to target (2...5...6 seconds). These foes move 66% slower. Initial effect: deals 20...68...80 cold damage.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 212 - $GC_I_SKILL_ID_FROZEN_BURST
@@ -819,7 +832,9 @@ Func BestTarget_ShardStorm($a_f_AggroRange)
 	; Hex Spell. Projectile: deals 10...70...85 cold damage. Target foe moves 66% slower (2...5...6 seconds).
 	; Concise description
 	; Spell. Projectile: deals 10...70...85 cold damage. Target foe moves 66% slower (2...5...6 seconds).
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 222 - $GC_I_SKILL_ID_LIGHTNING_STRIKE
@@ -833,7 +848,7 @@ Func BestTarget_LightningStrike($a_f_AggroRange)
 	; Hex Spell. Deals 5...41...50 lightning damage. 25% armor penetration. Hex for 3 seconds if Overcast. End effect: deals 5...41...50 lightning damage.
 	; Concise description
 	; Spell. Deals 5...41...50 lightning damage. 25% armor penetration. Hex for 3 seconds if Overcast. End effect: deals 5...41...50 lightning damage.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 227 - $GC_I_SKILL_ID_GLIMMERING_MARK
@@ -843,7 +858,7 @@ Func CanUse_GlimmeringMark()
 EndFunc
 
 Func BestTarget_GlimmeringMark($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 234 - $GC_I_SKILL_ID_DEEP_FREEZE
@@ -857,7 +872,7 @@ Func BestTarget_DeepFreeze($a_f_AggroRange)
 	; Hex Spell. Also hexes foes in the area of your target (10 seconds). These foes move 66% slower. Initial effect: deals 10...70...85 cold damage.
 	; Concise description
 	; Spell. Also hexes foes in the area of your target (10 seconds). These foes move 66% slower. Initial effect: deals 10...70...85 cold damage.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_AREA, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 235 - $GC_I_SKILL_ID_BLURRED_VISION
@@ -871,7 +886,7 @@ Func BestTarget_BlurredVision($a_f_AggroRange)
 	; Hex Spell. Also hexes foes adjacent to target (4...9...10 seconds). They have 50% chance to miss.
 	; Concise description
 	; Spell. Also hexes foes adjacent to target (4...9...10 seconds). They have 50% chance to miss.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 251 - $GC_I_SKILL_ID_SCOURGE_HEALING
@@ -885,7 +900,7 @@ Func BestTarget_ScourgeHealing($a_f_AggroRange)
 	; Hex Spell. (30 seconds.) Whenever target foe is healed, the healer takes 15...67...80 holy damage.
 	; Concise description
 	; Spell. (30 seconds.) Whenever target foe is healed, the healer takes 15...67...80 holy damage.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 253 - $GC_I_SKILL_ID_SCOURGE_SACRIFICE
@@ -899,7 +914,7 @@ Func BestTarget_ScourgeSacrifice($a_f_AggroRange)
 	; Hex Spell. Also hexes foes adjacent to target (8...18...20 seconds). Doubles Health sacrifice.
 	; Concise description
 	; Spell. Also hexes foes adjacent to target (8...18...20 seconds). Doubles Health sacrifice.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 264 - $GC_I_SKILL_ID_PACIFISM
@@ -913,7 +928,7 @@ Func BestTarget_Pacifism($a_f_AggroRange)
 	; Hex Spell. (8...18...20 seconds.) Target foe cannot attack. Ends if this foe takes damage.
 	; Concise description
 	; Spell. (8...18...20 seconds.) Target foe cannot attack. Ends if this foe takes damage.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 265 - $GC_I_SKILL_ID_AMITY
@@ -955,7 +970,7 @@ Func BestTarget_CrystalHaze($a_f_AggroRange)
 	; Hex Spell. (monster only) (30 seconds.) Also affects foes near target. Causes -1 Energy degeneration. Causes 10 Overcast whenever foes use an Energy skill.
 	; Concise description
 	; Spell. (monster only) (30 seconds.) Also affects foes near target. Causes -1 Energy degeneration. Causes 10 Overcast whenever foes use an Energy skill.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 534 - $GC_I_SKILL_ID_CRYSTAL_BONDS
@@ -969,7 +984,7 @@ Func BestTarget_CrystalBonds($a_f_AggroRange)
 	; Hex Spell. (monster only) Remove 1 enchantment. Target foe has reduced movement (15 seconds) and may not be the target of enchantments.
 	; Concise description
 	; Spell. (monster only) Remove 1 enchantment. Target foe has reduced movement (15 seconds) and may not be the target of enchantments.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
 EndFunc
 
 ; Skill ID: 542 - $GC_I_SKILL_ID_ORACLE_LINK
@@ -983,7 +998,7 @@ Func BestTarget_OracleLink($a_f_AggroRange)
 	; Hex Spell. You share a portion of your Energy regeneration with the Oracle.
 	; Concise description
 	; Spell. You share a portion of your Energy regeneration with the Oracle.
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 567 - $GC_I_SKILL_ID_SPONTANEOUS_COMBUSTION
@@ -1011,7 +1026,7 @@ Func BestTarget_MarkOfInsecurity($a_f_AggroRange)
 	; Elite Hex Spell. (5...21...25 seconds.) Causes 1...3...3 Health degeneration. Enchantments and stances expire 30...70...80% faster on target foe. Disables your non-Assassin skills (10 seconds).
 	; Concise description
 	; Hex Spell. (5...21...25 seconds.) Causes 1...3...3 Health degeneration. Enchantments and stances expire 30...70...80% faster on target foe. Disables your non-Assassin skills (10 seconds).
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 764 - $GC_I_SKILL_ID_WAIL_OF_DOOM
@@ -1025,7 +1040,7 @@ Func BestTarget_WailOfDoom($a_f_AggroRange)
 	; Elite Hex Spell. (1...3...4 second[s].) Target foe's attributes are 0.
 	; Concise description
 	; Hex Spell. (1...3...4 second[s].) Target foe's attributes are 0.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 785 - $GC_I_SKILL_ID_MARK_OF_DEATH
@@ -1039,7 +1054,7 @@ Func BestTarget_MarkOfDeath($a_f_AggroRange)
 	; Hex Spell. (4...9...10 seconds.) Target foe receives 33% less from healing.
 	; Concise description
 	; Spell. (4...9...10 seconds.) Target foe receives 33% less from healing.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 800 - $GC_I_SKILL_ID_ENDURING_TOXIN
@@ -1053,7 +1068,9 @@ Func BestTarget_EnduringToxin($a_f_AggroRange)
 	; Hex Spell. (5 seconds.) Causes -1...4...5 Health degeneration. Renewal: if the target foe is moving when this hex ends.
 	; Concise description
 	; Spell. (5 seconds.) Causes -1...4...5 Health degeneration. Renewal: if the target foe is moving when this hex ends.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 801 - $GC_I_SKILL_ID_SHROUD_OF_SILENCE
@@ -1067,7 +1084,7 @@ Func BestTarget_ShroudOfSilence($a_f_AggroRange)
 	; Hex Spell. (1...3...3 second[s].) Target foe cannot cast spells. Your spells are disabled for 15 seconds.
 	; Concise description
 	; Spell. (1...3...3 second[s].) Target foe cannot cast spells. Your spells are disabled for 15 seconds.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 802 - $GC_I_SKILL_ID_EXPOSE_DEFENSES
@@ -1081,7 +1098,7 @@ Func BestTarget_ExposeDefenses($a_f_AggroRange)
 	; Hex Spell. (1...9...11 second[s].) Target foe cannot block your attacks.
 	; Concise description
 	; Spell. (1...9...11 second[s].) Target foe cannot block your attacks.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 803 - $GC_I_SKILL_ID_POWER_LEECH
@@ -1095,7 +1112,7 @@ Func BestTarget_PowerLeech($a_f_AggroRange)
 	; Elite Hex Spell. Interrupt a spell or a chant. Interruption effect: steal 5...13...15 Energy whenever target foe casts a spell (10 seconds).
 	; Concise description
 	; Hex Spell. Interrupt a spell or a chant. Interruption effect: steal 5...13...15 Energy whenever target foe casts a spell (10 seconds).
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 804 - $GC_I_SKILL_ID_ARCANE_LANGUOR
@@ -1109,7 +1126,7 @@ Func BestTarget_ArcaneLanguor($a_f_AggroRange)
 	; Elite Hex Spell. (1...8...10 second[s].) Target foe's spells cause 10 Overcast.
 	; Concise description
 	; Hex Spell. (1...8...10 second[s].) Target foe's spells cause 10 Overcast.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 808 - $GC_I_SKILL_ID_REAPERS_MARK1
@@ -1123,7 +1140,7 @@ Func BestTarget_ReapersMark1($a_f_AggroRange)
 	; Elite Hex Spell. (30 seconds.) Causes -1...4...5 Health degeneration. You gain 5...13...15 Energy if target foe dies while suffering from this hex.
 	; Concise description
 	; Hex Spell. (30 seconds.) Causes -1...4...5 Health degeneration. You gain 5...13...15 Energy if target foe dies while suffering from this hex.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 809 - $GC_I_SKILL_ID_SHATTERSTONE
@@ -1137,7 +1154,7 @@ Func BestTarget_Shatterstone($a_f_AggroRange)
 	; Elite Hex Spell. (3 seconds.) Initial effect: deals 25...85...100 cold damage. End effect: deals 25...85...100 cold damage to target and all nearby foes.
 	; Concise description
 	; Hex Spell. (3 seconds.) Initial effect: deals 25...85...100 cold damage. End effect: deals 25...85...100 cold damage to target and all nearby foes.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 815 - $GC_I_SKILL_ID_SCORPION_WIRE
@@ -1151,7 +1168,7 @@ Func BestTarget_ScorpionWire($a_f_AggroRange)
 	; Hex Spell. (8...18...20 seconds.) Shadow Step to target foe and cause knock-down the next time this foe is more than 100' away from you.
 	; Concise description
 	; Spell. (8...18...20 seconds.) Shadow Step to target foe and cause knock-down the next time this foe is more than 100' away from you.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 816 - $GC_I_SKILL_ID_MIRRORED_STANCE
@@ -1165,7 +1182,7 @@ Func BestTarget_MirroredStance($a_f_AggroRange)
 	; Hex Spell. (10...30...35 seconds.) You enter any stance used by target foe.
 	; Concise description
 	; Spell. (10...30...35 seconds.) You enter any stance used by target foe.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 820 - $GC_I_SKILL_ID_DEPRAVITY
@@ -1179,7 +1196,7 @@ Func BestTarget_Depravity($a_f_AggroRange)
 	; Elite Hex Spell. (5...17...20 seconds.) Causes 1...4...5 Energy loss whenever target foe casts a spell. One foe near your target also loses Energy.
 	; Concise description
 	; Hex Spell. (5...17...20 seconds.) Causes 1...4...5 Energy loss whenever target foe casts a spell. One foe near your target also loses Energy.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 821 - $GC_I_SKILL_ID_ICY_VEINS
@@ -1207,7 +1224,9 @@ Func BestTarget_WeakenKnees($a_f_AggroRange)
 	; Elite Hex Spell. (1...13...16 second[s].) Target foe has -1...3...4 Health degeneration and takes 5...9...10 damage while moving.
 	; Concise description
 	; Hex Spell. (1...13...16 second[s].) Target foe has -1...3...4 Health degeneration and takes 5...9...10 damage while moving.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 827 - $GC_I_SKILL_ID_SIPHON_STRENGTH
@@ -1221,7 +1240,7 @@ Func BestTarget_SiphonStrength($a_f_AggroRange)
 	; Elite Hex Spell. (5...17...20 seconds.) Target foe deals -5...41...50 attack damage. You have +33% chance to land a critical hit on this foe.
 	; Concise description
 	; Hex Spell. (5...17...20 seconds.) Target foe deals -5...41...50 attack damage. You have +33% chance to land a critical hit on this foe.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 828 - $GC_I_SKILL_ID_VILE_MIASMA
@@ -1235,7 +1254,7 @@ Func BestTarget_VileMiasma($a_f_AggroRange)
 	; Hex Spell. Causes -1...4...5 Health degeneration (10 seconds). Initial effect: deals 10...54...65 cold damage. Hex is only applied if target foe has a condition.
 	; Concise description
 	; Spell. Causes -1...4...5 Health degeneration (10 seconds). Initial effect: deals 10...54...65 cold damage. Hex is only applied if target foe has a condition.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 834 - $GC_I_SKILL_ID_RECKLESS_HASTE
@@ -1249,7 +1268,7 @@ Func BestTarget_RecklessHaste($a_f_AggroRange)
 	; Hex Spell. Also hexes foes adjacent to your target (6...11...12 seconds). These foes have 50% chance to miss, but attack 25% faster.
 	; Concise description
 	; Spell. Also hexes foes adjacent to your target (6...11...12 seconds). These foes have 50% chance to miss, but attack 25% faster.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 835 - $GC_I_SKILL_ID_BLOOD_BOND
@@ -1263,7 +1282,7 @@ Func BestTarget_BloodBond($a_f_AggroRange)
 	; Hex Spell. Also hexes foes adjacent to your target (3...10...12 seconds). Allies hitting these foes gain 5...17...20 health. If any of these foes dies while hexed, adjacent allies are healed for 20...84...100.
 	; Concise description
 	; Spell. Also hexes foes adjacent to your target (3...10...12 seconds). Allies hitting these foes gain 5...17...20 health. If any of these foes dies while hexed, adjacent allies are healed for 20...84...100.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 859 - $GC_I_SKILL_ID_CONJURE_NIGHTMARE
@@ -1277,7 +1296,7 @@ Func BestTarget_ConjureNightmare($a_f_AggroRange)
 	; Hex Spell. (2...13...16 seconds.) Causes -8 Health degeneration.
 	; Concise description
 	; Spell. (2...13...16 seconds.) Causes -8 Health degeneration.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 861 - $GC_I_SKILL_ID_DISSIPATION
@@ -1287,7 +1306,7 @@ Func CanUse_Dissipation()
 EndFunc
 
 Func BestTarget_Dissipation($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 878 - $GC_I_SKILL_ID_VISIONS_OF_REGRET
@@ -1301,7 +1320,7 @@ Func BestTarget_VisionsOfRegret($a_f_AggroRange)
 	; Elite Hex Spell. Also hexes foes adjacent to target (10 seconds). These foes take 15...39...45 damage whenever they use a skill and 5...41...50 additional damage if not under the effects of another Mesmer hex.
 	; Concise description
 	; Hex Spell. Also hexes foes adjacent to target (10 seconds). These foes take 15...39...45 damage whenever they use a skill and 5...41...50 additional damage if not under the effects of another Mesmer hex.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 879 - $GC_I_SKILL_ID_ILLUSION_OF_PAIN
@@ -1315,7 +1334,7 @@ Func BestTarget_IllusionOfPain($a_f_AggroRange)
 	; Hex Spell. (8 seconds.) Causes -3...9...10 Health degeneration and target foe takes 3...9...10 damage each second. End effect: that foe is healed for 36...103...120.
 	; Concise description
 	; Spell. (8 seconds.) Causes -3...9...10 Health degeneration and target foe takes 3...9...10 damage each second. End effect: that foe is healed for 36...103...120.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 880 - $GC_I_SKILL_ID_STOLEN_SPEED
@@ -1329,7 +1348,7 @@ Func BestTarget_StolenSpeed($a_f_AggroRange)
 	; Elite Hex Spell. Also hexes adjacent foes (1...8...10 seconds). Doubles spell casting time. Spells cast by you or your allies have -50% casting times.
 	; Concise description
 	; Hex Spell. Also hexes adjacent foes (1...8...10 seconds). Doubles spell casting time. Spells cast by you or your allies have -50% casting times.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 883 - $GC_I_SKILL_ID_VOCAL_MINORITY
@@ -1343,7 +1362,7 @@ Func BestTarget_VocalMinority($a_f_AggroRange)
 	; Hex Spell. Also hexes foes near target (5...17...20 seconds). These foes cannot use shouts or chants.
 	; Concise description
 	; Spell. Also hexes foes near target (5...17...20 seconds). These foes cannot use shouts or chants.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 898 - $GC_I_SKILL_ID_OVERLOAD
@@ -1373,7 +1392,7 @@ Func BestTarget_ImagesOfRemorse($a_f_AggroRange)
 	; Hex Spell. (5...9...10 seconds.) Causes -1...3...3 Health degeneration. Initial effect: 10...44...52 damage if target foe is attacking.
 	; Concise description
 	; Spell. (5...9...10 seconds.) Causes -1...3...3 Health degeneration. Initial effect: 10...44...52 damage if target foe is attacking.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 900 - $GC_I_SKILL_ID_SHARED_BURDEN
@@ -1387,7 +1406,7 @@ Func BestTarget_SharedBurden($a_f_AggroRange)
 	; Elite Hex Spell. Also hexes foes near your target (5...17...20 seconds). These foes attack, cast spells, and move 50% slower.
 	; Concise description
 	; Hex Spell. Also hexes foes near your target (5...17...20 seconds). These foes attack, cast spells, and move 50% slower.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 901 - $GC_I_SKILL_ID_SOUL_BIND
@@ -1401,7 +1420,7 @@ Func BestTarget_SoulBind($a_f_AggroRange)
 	; Elite Hex Spell. (30 seconds.) Every time target foe is healed, the healer takes 20...68...80 damage. Ends if target is suffering from a Smiting Prayers hex.
 	; Concise description
 	; Hex Spell. (30 seconds.) Every time target foe is healed, the healer takes 20...68...80 damage. Ends if target is suffering from a Smiting Prayers hex.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 916 - $GC_I_SKILL_ID_LAMENTATION
@@ -1415,7 +1434,7 @@ Func BestTarget_Lamentation($a_f_AggroRange)
 	; Hex Spell. Also hexes foes near your target (5...17...20 seconds). Causes -0...2...3 Health degeneration. Initial effect: Deals 10...42...50 damage to these foes if you are within earshot of a spirit or corpse.
 	; Concise description
 	; Spell. Also hexes foes near your target (5...17...20 seconds). Causes -0...2...3 Health degeneration. Initial effect: Deals 10...42...50 damage to these foes if you are within earshot of a spirit or corpse.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 927 - $GC_I_SKILL_ID_SHAMEFUL_FEAR
@@ -1429,7 +1448,9 @@ Func BestTarget_ShamefulFear($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) Target foe takes 5...17...20 damage each second while moving, but moves 10% faster.
 	; Concise description
 	; Spell. (10 seconds.) Target foe takes 5...17...20 damage each second while moving, but moves 10% faster.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 928 - $GC_I_SKILL_ID_SHADOW_SHROUD
@@ -1443,7 +1464,7 @@ Func BestTarget_ShadowShroud($a_f_AggroRange)
 	; Elite Hex Spell. (3...8...9 seconds.) Target foe cannot be the target of enchantments.
 	; Concise description
 	; Hex Spell. (3...8...9 seconds.) Target foe cannot be the target of enchantments.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 935 - $GC_I_SKILL_ID_RISING_BILE
@@ -1471,7 +1492,11 @@ Func BestTarget_IcyShackles($a_f_AggroRange)
 	; Elite Hex Spell. (1...8...10 second[s].) Target foe moves 66% slower. This foe moves 90% slower if enchanted.
 	; Concise description
 	; Hex Spell. (1...8...10 second[s].) Target foe moves 66% slower. This foe moves 90% slower if enchanted.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 950 - $GC_I_SKILL_ID_SHADOWY_BURDEN
@@ -1485,7 +1510,9 @@ Func BestTarget_ShadowyBurden($a_f_AggroRange)
 	; Hex Spell. (3...13...15 seconds.) Target foe moves 25% slower and has 20 less armor against your attacks. Armor reduction only affects this foe while it has no other hexes.
 	; Concise description
 	; Spell. (3...13...15 seconds.) Target foe moves 25% slower and has 20 less armor against your attacks. Armor reduction only affects this foe while it has no other hexes.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 951 - $GC_I_SKILL_ID_SIPHON_SPEED
@@ -1499,7 +1526,9 @@ Func BestTarget_SiphonSpeed($a_f_AggroRange)
 	; Hex Spell. (5...13...15 seconds.) Target foe moves 33% slower and you move 33% faster. Recharges 50% faster if cast on a moving foe.
 	; Concise description
 	; Spell. (5...13...15 seconds.) Target foe moves 33% slower and you move 33% faster. Recharges 50% faster if cast on a moving foe.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 953 - $GC_I_SKILL_ID_POWER_FLUX
@@ -1513,7 +1542,7 @@ Func BestTarget_PowerFlux($a_f_AggroRange)
 	; Elite Hex Spell. Interrupts a spell or chant. Interruption effect: -2 Energy degeneration (4...9...10 seconds).
 	; Concise description
 	; Hex Spell. Interrupts a spell or chant. Interruption effect: -2 Energy degeneration (4...9...10 seconds).
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 978 - $GC_I_SKILL_ID_MARK_OF_INSTABILITY
@@ -1527,7 +1556,7 @@ Func BestTarget_MarkOfInstability($a_f_AggroRange)
 	; Hex Spell. (20 seconds.) Causes knock-down the next time you hit target foe with a dual attack.
 	; Concise description
 	; Spell. (20 seconds.) Causes knock-down the next time you hit target foe with a dual attack.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 979 - $GC_I_SKILL_ID_MISTRUST
@@ -1541,7 +1570,7 @@ Func BestTarget_Mistrust($a_f_AggroRange)
 	; Hex Spell. (6 seconds.) The next spell that target foe casts on one of your allies fails and deals 10...82...100 damage to target and nearby foes.
 	; Concise description
 	; Spell. (6 seconds.) The next spell that target foe casts on one of your allies fails and deals 10...82...100 damage to target and nearby foes.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 998 - $GC_I_SKILL_ID_TORCH_HEX
@@ -1575,7 +1604,7 @@ Func BestTarget_SnowDownTheShirt($a_f_AggroRange)
 	; Hex Spell. (20 seconds.) Interrupts target foe whenever it takes damage.
 	; Concise description
 	; Spell. (20 seconds.) Interrupts target foe whenever it takes damage.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1012 - $GC_I_SKILL_ID_ICICLES
@@ -1589,7 +1618,7 @@ Func BestTarget_Icicles($a_f_AggroRange)
 	; Hex Spell. Deals 75 cold damage to target and adjacent foes. These foes move 66% slower (5 seconds).
 	; Concise description
 	; Spell. Deals 75 cold damage to target and adjacent foes. These foes move 66% slower (5 seconds).
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1034 - $GC_I_SKILL_ID_SEEPING_WOUND
@@ -1603,7 +1632,9 @@ Func BestTarget_SeepingWound($a_f_AggroRange)
 	; Hex Spell. (1...6...7 second[s].) Target foe moves 33% slower. This foe takes 5...21...25 damage each second while suffering from a condition.
 	; Concise description
 	; Spell. (1...6...7 second[s].) Target foe moves 33% slower. This foe takes 5...21...25 damage each second while suffering from a condition.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1035 - $GC_I_SKILL_ID_ASSASSINS_PROMISE
@@ -1631,7 +1662,9 @@ Func BestTarget_DarkPrison($a_f_AggroRange)
 	; Hex Spell. Shadow Step to target foe. This foe moves 33% slower (1...5...6 seconds).
 	; Concise description
 	; Spell. Shadow Step to target foe. This foe moves 33% slower (1...5...6 seconds).
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1051 - $GC_I_SKILL_ID_EMPATHY_KORO
@@ -1641,7 +1674,7 @@ Func CanUse_EmpathyKoro()
 EndFunc
 
 Func BestTarget_EmpathyKoro($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 1055 - $GC_I_SKILL_ID_RECURRING_INSECURITY
@@ -1655,7 +1688,7 @@ Func BestTarget_RecurringInsecurity($a_f_AggroRange)
 	; Elite Hex Spell. (10 seconds.) Causes -1...4...5 Health degeneration. Renewal: if target foe has another hex when Recurring Insecurity would end.
 	; Concise description
 	; Hex Spell. (10 seconds.) Causes -1...4...5 Health degeneration. Renewal: if target foe has another hex when Recurring Insecurity would end.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1056 - $GC_I_SKILL_ID_KITAHS_BURDEN
@@ -1669,7 +1702,9 @@ Func BestTarget_KitahsBurden($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) Target foe moves 50% slower. End effect: you gain 10...16...18 Energy.
 	; Concise description
 	; Spell. (10 seconds.) Target foe moves 50% slower. End effect: you gain 10...16...18 Energy.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1066 - $GC_I_SKILL_ID_SPOIL_VICTOR
@@ -1683,7 +1718,7 @@ Func BestTarget_SpoilVictor($a_f_AggroRange)
 	; Elite Hex Spell. (3...13...15 seconds.) Causes 25...85...100 Health loss whenever target foe attacks or casts spells on a creature with less Health.
 	; Concise description
 	; Hex Spell. (3...13...15 seconds.) Causes 25...85...100 Health loss whenever target foe attacks or casts spells on a creature with less Health.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 1071 - $GC_I_SKILL_ID_SHIVERS_OF_DREAD
@@ -1693,7 +1728,7 @@ Func CanUse_ShiversOfDread()
 EndFunc
 
 Func BestTarget_ShiversOfDread($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1085 - $GC_I_SKILL_ID_ASH_BLAST
@@ -1707,7 +1742,7 @@ Func BestTarget_AshBlast($a_f_AggroRange)
 	; Hex Spell. Deals 35...59...65 earth damage. Burning foes are hexed for 5 seconds and miss 20...64...75% of attacks. Also strikes adjacent.
 	; Concise description
 	; Spell. Deals 35...59...65 earth damage. Burning foes are hexed for 5 seconds and miss 20...64...75% of attacks. Also strikes adjacent.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1090 - $GC_I_SKILL_ID_SMOLDERING_EMBERS
@@ -1721,7 +1756,7 @@ Func BestTarget_SmolderingEmbers($a_f_AggroRange)
 	; Hex Spell. Deals 10...58...70 fire damage to target. If you are Overcast, foe is hexed for 3 seconds, taking 5...21...25 fire damage each second.
 	; Concise description
 	; Spell. Deals 10...58...70 fire damage to target. If you are Overcast, foe is hexed for 3 seconds, taking 5...21...25 fire damage each second.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1097 - $GC_I_SKILL_ID_TEINAIS_PRISON
@@ -1735,7 +1770,9 @@ Func BestTarget_TeinaisPrison($a_f_AggroRange)
 	; Hex Spell. (1...5...6 second[s].) Target foe moves 66% slower. Foes with Cracked Armor have 5...8...9 Health degeneration.
 	; Concise description
 	; Spell. (1...5...6 second[s].) Target foe moves 66% slower. Foes with Cracked Armor have 5...8...9 Health degeneration.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1098 - $GC_I_SKILL_ID_MIRROR_OF_ICE
@@ -1749,7 +1786,7 @@ Func BestTarget_MirrorOfIce($a_f_AggroRange)
 	; Elite Hex Spell. Deals 15...59...70 cold damage and slows foes by 66% (2...5...6 seconds). Hits foes near you and target ally. Recharges 50% faster if it hits a foe hexed with Water Magic.
 	; Concise description
 	; Hex Spell. Deals 15...59...70 cold damage and slows foes by 66% (2...5...6 seconds). Hits foes near you and target ally. Recharges 50% faster if it hits a foe hexed with Water Magic.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1157 - $GC_I_SKILL_ID_STAR_SHARDS
@@ -1778,7 +1815,7 @@ Func BestTarget_DulledWeapon($a_f_AggroRange)
 	; Hex Spell. Also hexes foes adjacent to your target (5...13...15 seconds). Removes ability to land a critical hit. Reduces damage by 1...12...15.
 	; Concise description
 	; Spell. Also hexes foes adjacent to your target (5...13...15 seconds). Removes ability to land a critical hit. Reduces damage by 1...12...15.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1236 - $GC_I_SKILL_ID_BINDING_CHAINS
@@ -1792,7 +1829,7 @@ Func BestTarget_BindingChains($a_f_AggroRange)
 	; Hex Spell. Also hexes foes near your target. (3 seconds.) These foes move 90% slower and takes 1...24...30 damage each second while moving.
 	; Concise description
 	; Spell. Also hexes foes near your target. (3 seconds.) These foes move 90% slower and takes 1...24...30 damage each second while moving.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1237 - $GC_I_SKILL_ID_PAINFUL_BOND
@@ -1820,7 +1857,7 @@ Func BestTarget_Meekness($a_f_AggroRange)
 	; Hex Spell. Also hexes foes in the area of target (5...25...30 seconds). These foes attack 50% slower.
 	; Concise description
 	; Spell. Also hexes foes in the area of target (5...25...30 seconds). These foes attack 50% slower.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_AREA, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1272 - $GC_I_SKILL_ID_SUICIDAL_IMPULSE
@@ -1864,7 +1901,7 @@ Func BestTarget_Frustration($a_f_AggroRange)
 	; Hex Spell. (5...17...20 seconds.) Causes 50% slower spell casting. Target foe takes 5...41...50 damage whenever interrupted. Deals double damage on skill interrupt.
 	; Concise description
 	; Spell. (5...17...20 seconds.) Causes 50% slower spell casting. Target foe takes 5...41...50 damage whenever interrupted. Deals double damage on skill interrupt.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 1343 - $GC_I_SKILL_ID_ETHER_PHANTOM
@@ -1878,7 +1915,7 @@ Func BestTarget_EtherPhantom($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) Causes -1 Energy degeneration. Causes 1...4...5 Energy loss if this hex ends early.
 	; Concise description
 	; Spell. (10 seconds.) Causes -1 Energy degeneration. Causes 1...4...5 Energy loss if this hex ends early.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 1344 - $GC_I_SKILL_ID_WEB_OF_DISRUPTION
@@ -1892,7 +1929,7 @@ Func BestTarget_WebOfDisruption($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) Initial effect: interrupts a skill. End effect: interrupts a skill.
 	; Concise description
 	; Spell. (10 seconds.) Initial effect: interrupts a skill. End effect: interrupts a skill.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 1345 - $GC_I_SKILL_ID_ENCHANTERS_CONUNDRUM
@@ -1906,7 +1943,7 @@ Func BestTarget_EnchantersConundrum($a_f_AggroRange)
 	; Elite Hex Spell. Causes 100...180...200% slower enchantment casting (10 seconds). Initial effect: deals 10...82...100 damage to target and adjacent foes if target foe is not enchanted.
 	; Concise description
 	; Hex Spell. Causes 100...180...200% slower enchantment casting (10 seconds). Initial effect: deals 10...82...100 damage to target and adjacent foes if target foe is not enchanted.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1358 - $GC_I_SKILL_ID_ULCEROUS_LUNGS
@@ -1920,7 +1957,7 @@ Func BestTarget_UlcerousLungs($a_f_AggroRange)
 	; Hex Spell. Also hexes foes near your target (10...22...25 seconds). Causes -4 Health degeneration to any of these foes that are Bleeding. Inflicts Bleeding (3...13...15 seconds) whenever these foes use a shout or chant.
 	; Concise description
 	; Spell. Also hexes foes near your target (10...22...25 seconds). Causes -4 Health degeneration to any of these foes that are Bleeding. Inflicts Bleeding (3...13...15 seconds) whenever these foes use a shout or chant.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1360 - $GC_I_SKILL_ID_MARK_OF_FURY
@@ -1934,7 +1971,7 @@ Func BestTarget_MarkOfFury($a_f_AggroRange)
 	; Hex Spell. (5 seconds.) Allies hitting target foe gain 0...2...2 strike[s] of adrenaline. End effect: inflicts Cracked Armor (1...12...15 second[s].)
 	; Concise description
 	; Spell. (5 seconds.) Allies hitting target foe gain 0...2...2 strike[s] of adrenaline. End effect: inflicts Cracked Armor (1...12...15 second[s].)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 1361 - $GC_I_SKILL_ID_RECURRING_SCOURGE
@@ -1944,7 +1981,7 @@ Func CanUse_RecurringScourge()
 EndFunc
 
 Func BestTarget_RecurringScourge($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1362 - $GC_I_SKILL_ID_CORRUPT_ENCHANTMENT
@@ -1958,7 +1995,7 @@ Func BestTarget_CorruptEnchantment($a_f_AggroRange)
 	; Elite Hex Spell. Removes one enchantment from target foe. Removal effect: -1...7...8 Health degeneration (10 seconds).
 	; Concise description
 	; Hex Spell. Removes one enchantment from target foe. Removal effect: -1...7...8 Health degeneration (10 seconds).
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
 EndFunc
 
 ; Skill ID: 1368 - $GC_I_SKILL_ID_CHILLING_WINDS
@@ -1972,7 +2009,7 @@ Func BestTarget_ChillingWinds($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) The next water hex on target foe lasts 25...85...100% longer. Initial effect: 30...54...60 cold damage. Also strikes adjacent.
 	; Concise description
 	; Spell. (10 seconds.) The next water hex on target foe lasts 25...85...100% longer. Initial effect: 30...54...60 cold damage. Also strikes adjacent.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1382 - $GC_I_SKILL_ID_FREEZING_GUST
@@ -1986,7 +2023,9 @@ Func BestTarget_FreezingGust($a_f_AggroRange)
 	; Hex Spell. Deals 20...68...80 cold damage if target foe is hexed with Water Magic. Otherwise, this foe moves 66% slower (1...4...5 second[s]).
 	; Concise description
 	; Spell. Deals 20...68...80 cold damage if target foe is hexed with Water Magic. Otherwise, this foe moves 66% slower (1...4...5 second[s]).
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1398 - $GC_I_SKILL_ID_SCOURGE_ENCHANTMENT
@@ -2000,7 +2039,7 @@ Func BestTarget_ScourgeEnchantment($a_f_AggroRange)
 	; Hex Spell. (30 seconds.) Deals 15...63...75 damage to anyone casting an enchantment on target foe.
 	; Concise description
 	; Spell. (30 seconds.) Deals 15...63...75 damage to anyone casting an enchantment on target foe.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1417 - $GC_I_SKILL_ID_VIAL_OF_PURIFIED_WATER
@@ -2028,7 +2067,7 @@ Func BestTarget_CorsairsNet($a_f_AggroRange)
 	; Hex Spell. Quarter speed projectile: target and foes in the area move slower (10 seconds).
 	; Concise description
 	; Spell. Quarter speed projectile: target and foes in the area move slower (10 seconds).
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_AREA, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1449 - $GC_I_SKILL_ID_LAST_RITES_OF_TORMENT
@@ -2052,7 +2091,7 @@ Func BestTarget_EnchantmentCollapse($a_f_AggroRange)
 	; Hex Spell. Target foe loses all enchantments each time this foe loses an enchantment.
 	; Concise description
 	; Spell. Target foe loses all enchantments each time this foe loses an enchantment.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
 EndFunc
 
 ; Skill ID: 1459 - $GC_I_SKILL_ID_CALL_OF_SACRIFICE
@@ -2066,7 +2105,7 @@ Func BestTarget_CallOfSacrifice($a_f_AggroRange)
 	; Hex Spell. (20 seconds.) Target loses 20 Health each second. Ends sooner if target is at less than 20% Health.
 	; Concise description
 	; Spell. (20 seconds.) Target loses 20 Health each second. Ends sooner if target is at less than 20% Health.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1478 - $GC_I_SKILL_ID_RENEWING_SURGE
@@ -2095,7 +2134,9 @@ Func BestTarget_HiddenCaltrops($a_f_AggroRange)
 	; Elite Hex Spell. (1...8...10 seconds.) Causes 50% slower movement. End effect: inflicts Crippled condition (1...12...15 seconds). Your non-Assassin skills are disabled (10 seconds.)
 	; Concise description
 	; Hex Spell. (1...8...10 seconds.) Causes 50% slower movement. End effect: inflicts Crippled condition (1...12...15 seconds). Your non-Assassin skills are disabled (10 seconds.)
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1646 - $GC_I_SKILL_ID_AUGURY_OF_DEATH
@@ -2105,7 +2146,7 @@ Func CanUse_AuguryOfDeath()
 EndFunc
 
 Func BestTarget_AuguryOfDeath($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1652 - $GC_I_SKILL_ID_SHADOW_PRISON
@@ -2119,7 +2160,9 @@ Func BestTarget_ShadowPrison($a_f_AggroRange)
 	; Elite Hex Spell. Shadow Step to target foe. This foe moves 66% slower (1...6...7 seconds).
 	; Concise description
 	; Hex Spell. Shadow Step to target foe. This foe moves 66% slower (1...6...7 seconds).
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1655 - $GC_I_SKILL_ID_PRICE_OF_PRIDE
@@ -2133,7 +2176,7 @@ Func BestTarget_PriceOfPride($a_f_AggroRange)
 	; Hex Spell. (5...17...20 seconds.) Causes 1...6...7 Energy loss the next time target foe uses an elite skill.
 	; Concise description
 	; Spell. (5...17...20 seconds.) Causes 1...6...7 Energy loss the next time target foe uses an elite skill.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 1656 - $GC_I_SKILL_ID_AIR_OF_DISENCHANTMENT
@@ -2147,7 +2190,7 @@ Func BestTarget_AirOfDisenchantment($a_f_AggroRange)
 	; Elite Hex Spell. Also hexes foes near your target (5...17...20 seconds). Remove one enchantment from target and nearby foes. Enchantments expire 150...270...300% faster on those foes.
 	; Concise description
 	; Hex Spell. Also hexes foes near your target (5...17...20 seconds). Remove one enchantment from target and nearby foes. Enchantments expire 150...270...300% faster on those foes.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1688 - $GC_I_SKILL_ID_DEFENDERS_ZEAL
@@ -2161,7 +2204,7 @@ Func BestTarget_DefendersZeal($a_f_AggroRange)
 	; Elite Hex Spell. (5...21...25 seconds.) You gain 2 Energy whenever target foe hits with an attack.
 	; Concise description
 	; Hex Spell. (5...21...25 seconds.) You gain 2 Energy whenever target foe hits with an attack.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 1707 - $GC_I_SKILL_ID_WORDS_OF_MADNESS_QWYTZYLKAK
@@ -2181,7 +2224,7 @@ Func CanUse_MadnessDart()
 EndFunc
 
 Func BestTarget_MadnessDart($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1881 - $GC_I_SKILL_ID_BONDS_OF_TORMENT
@@ -2195,7 +2238,7 @@ Func BestTarget_BondsOfTorment($a_f_AggroRange)
 	; Hex Spell. Any time the caster takes damage, all foes hexed with Bonds of Torment take equal cold damage.
 	; Concise description
 	; Spell. Any time the caster takes damage, all foes hexed with Bonds of Torment take equal cold damage.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1949 - $GC_I_SKILL_ID_ETHER_NIGHTMARE_LUXON
@@ -2205,7 +2248,7 @@ Func CanUse_EtherNightmareLuxon()
 EndFunc
 
 Func BestTarget_EtherNightmareLuxon($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1996 - $GC_I_SKILL_ID_SUM_OF_ALL_FEARS
@@ -2219,7 +2262,9 @@ Func BestTarget_SumOfAllFears($a_f_AggroRange)
 	; Hex Spell. (1...8...10 second[s].) Target foe moves, attacks, and casts spells 33% slower.
 	; Concise description
 	; Spell. (1...8...10 second[s].) Target foe moves, attacks, and casts spells 33% slower.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1998 - $GC_I_SKILL_ID_CACOPHONY
@@ -2233,7 +2278,7 @@ Func BestTarget_Cacophony($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) Deals 35...91...105 damage whenever target foe uses a shout or chant.
 	; Concise description
 	; Spell. (10 seconds.) Deals 35...91...105 damage whenever target foe uses a shout or chant.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1999 - $GC_I_SKILL_ID_WINTERS_EMBRACE
@@ -2247,7 +2292,9 @@ Func BestTarget_WintersEmbrace($a_f_AggroRange)
 	; Hex Spell. (2...5...6 seconds.) Target foe moves 66% slower and takes 5...13...15 damage while moving.
 	; Concise description
 	; Spell. (2...5...6 seconds.) Target foe moves 66% slower and takes 5...13...15 damage while moving.
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2000 - $GC_I_SKILL_ID_EARTHEN_SHACKLES
@@ -2261,7 +2308,7 @@ Func BestTarget_EarthenShackles($a_f_AggroRange)
 	; Hex Spell. (3 seconds.) Target and nearby foes move 90% slower. Applies Weakness for 5...17...20 seconds when it ends.
 	; Concise description
 	; Spell. (3 seconds.) Target and nearby foes move 90% slower. Applies Weakness for 5...17...20 seconds when it ends.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2052 - $GC_I_SKILL_ID_SHADOW_FANG
@@ -2275,7 +2322,7 @@ Func BestTarget_ShadowFang($a_f_AggroRange)
 	; Hex Spell. Shadow Step to target foe. End effect after 10 seconds: inflicts Deep Wound condition (5...17...20 seconds); you return to your original location.
 	; Concise description
 	; Spell. Shadow Step to target foe. End effect after 10 seconds: inflicts Deep Wound condition (5...17...20 seconds); you return to your original location.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2053 - $GC_I_SKILL_ID_CALCULATED_RISK
@@ -2289,7 +2336,7 @@ Func BestTarget_CalculatedRisk($a_f_AggroRange)
 	; Hex Spell. Target foe does +10 damage with attacks (3...20...24 seconds). There is a 50% chance that the damage from each attack (maximum 15...83...100) will be done to that foe instead.
 	; Concise description
 	; Spell. Target foe does +10 damage with attacks (3...20...24 seconds). There is a 50% chance that the damage from each attack (maximum 15...83...100) will be done to that foe instead.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 2054 - $GC_I_SKILL_ID_SHRINKING_ARMOR
@@ -2303,7 +2350,7 @@ Func BestTarget_ShrinkingArmor($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) Causes -1...3...4 Health degeneration. End effect: inflicts Cracked Armor condition (5...17...20 seconds).
 	; Concise description
 	; Spell. (10 seconds.) Causes -1...3...4 Health degeneration. End effect: inflicts Cracked Armor condition (5...17...20 seconds).
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2056 - $GC_I_SKILL_ID_WANDERING_EYE
@@ -2345,7 +2392,7 @@ Func BestTarget_SnaringWeb($a_f_AggroRange)
 	; Hex Spell. Projectile: target and nearby foes are Crippled and activate skills 100% slower (15 seconds.)
 	; Concise description
 	; Spell. Projectile: target and nearby foes are Crippled and activate skills 100% slower (15 seconds.)
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2089 - $GC_I_SKILL_ID_WURM_BILE
@@ -2359,7 +2406,7 @@ Func BestTarget_WurmBile($a_f_AggroRange)
 	; Hex Spell. (20 seconds.) Deals 40 damage each second to nearby foes.
 	; Concise description
 	; Spell. (20 seconds.) Deals 40 damage each second to nearby foes.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2092 - $GC_I_SKILL_ID_ETHER_NIGHTMARE_KURZICK
@@ -2369,7 +2416,7 @@ Func CanUse_EtherNightmareKurzick()
 EndFunc
 
 Func BestTarget_EtherNightmareKurzick($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2122 - $GC_I_SKILL_ID_SPIRIT_WORLD_RETREAT
@@ -2397,7 +2444,7 @@ Func BestTarget_ConfusingImages($a_f_AggroRange)
 	; Hex Spell. (2...8...10 seconds). Target foe takes twice as long to activate non-attack skills.
 	; Concise description
 	; Spell. (2...8...10 seconds). Target foe takes twice as long to activate non-attack skills.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 2188 - $GC_I_SKILL_ID_DEFILE_DEFENSES
@@ -2411,7 +2458,7 @@ Func BestTarget_DefileDefenses($a_f_AggroRange)
 	; Hex Spell. (5...17...20 seconds.) Deals 30...102...120 damage the next time target foe blocks.
 	; Concise description
 	; Spell. (5...17...20 seconds.) Deals 30...102...120 damage the next time target foe blocks.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 2237 - $GC_I_SKILL_ID_ATROPHY
@@ -2425,7 +2472,7 @@ Func BestTarget_Atrophy($a_f_AggroRange)
 	; Hex Spell. (3...6...7 seconds.) Reduces this foe's primary attribute to 0.
 	; Concise description
 	; Spell. (3...6...7 seconds.) Reduces this foe's primary attribute to 0.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2254 - $GC_I_SKILL_ID_POLYMOCK_GLYPH_DESTABILIZATION
@@ -2435,7 +2482,7 @@ Func CanUse_PolymockGlyphDestabilization()
 EndFunc
 
 Func BestTarget_PolymockGlyphDestabilization($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2255 - $GC_I_SKILL_ID_POLYMOCK_MIND_WRECK
@@ -2445,7 +2492,7 @@ Func CanUse_PolymockMindWreck()
 EndFunc
 
 Func BestTarget_PolymockMindWreck($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 2261 - $GC_I_SKILL_ID_POLYMOCK_RISING_BILE
@@ -2455,7 +2502,7 @@ Func CanUse_PolymockRisingBile()
 EndFunc
 
 Func BestTarget_PolymockRisingBile($a_f_AggroRange)
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_AREA, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2281 - $GC_I_SKILL_ID_POLYMOCK_GLYPH_FREEZE
@@ -2465,7 +2512,7 @@ Func CanUse_PolymockGlyphFreeze()
 EndFunc
 
 Func BestTarget_PolymockGlyphFreeze($a_f_AggroRange)
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_AREA, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2284 - $GC_I_SKILL_ID_POLYMOCK_CALCULATED_RISK
@@ -2475,7 +2522,7 @@ Func CanUse_PolymockCalculatedRisk()
 EndFunc
 
 Func BestTarget_PolymockCalculatedRisk($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 2285 - $GC_I_SKILL_ID_POLYMOCK_RECURRING_INSECURITY
@@ -2485,7 +2532,7 @@ Func CanUse_PolymockRecurringInsecurity()
 EndFunc
 
 Func BestTarget_PolymockRecurringInsecurity($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2286 - $GC_I_SKILL_ID_POLYMOCK_BACKFIRE
@@ -2495,7 +2542,7 @@ Func CanUse_PolymockBackfire()
 EndFunc
 
 Func BestTarget_PolymockBackfire($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 2287 - $GC_I_SKILL_ID_POLYMOCK_GUILT
@@ -2505,7 +2552,7 @@ Func CanUse_PolymockGuilt()
 EndFunc
 
 Func BestTarget_PolymockGuilt($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 2290 - $GC_I_SKILL_ID_POLYMOCK_PAINFUL_BOND
@@ -2515,7 +2562,7 @@ Func CanUse_PolymockPainfulBond()
 EndFunc
 
 Func BestTarget_PolymockPainfulBond($a_f_AggroRange)
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2292 - $GC_I_SKILL_ID_POLYMOCK_MIGRAINE
@@ -2525,7 +2572,7 @@ Func CanUse_PolymockMigraine()
 EndFunc
 
 Func BestTarget_PolymockMigraine($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 2304 - $GC_I_SKILL_ID_POLYMOCK_DIVERSION
@@ -2535,7 +2582,7 @@ Func CanUse_PolymockDiversion()
 EndFunc
 
 Func BestTarget_PolymockDiversion($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 2307 - $GC_I_SKILL_ID_POLYMOCK_ICY_BONDS
@@ -2545,7 +2592,7 @@ Func CanUse_PolymockIcyBonds()
 EndFunc
 
 Func BestTarget_PolymockIcyBonds($a_f_AggroRange)
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2329 - $GC_I_SKILL_ID_CRYSTAL_SNARE
@@ -2559,7 +2606,7 @@ Func BestTarget_CrystalSnare($a_f_AggroRange)
 	; Hex Spell. (10 seconds.) You move 50% slower. You take 100 damage if this hex ends before it is removed.
 	; Concise description
 	; Spell. (10 seconds.) You move 50% slower. You take 100 damage if this hex ends before it is removed.
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2330 - $GC_I_SKILL_ID_PARANOID_INDIGNATION
@@ -2573,7 +2620,7 @@ Func BestTarget_ParanoidIndignation($a_f_AggroRange)
 	; Hex Spell. (20 seconds.) -2 from your non-zero Attributes.
 	; Concise description
 	; Spell. (20 seconds.) -2 from your non-zero Attributes.
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2357 - $GC_I_SKILL_ID_A_TOUCH_OF_GUILE
@@ -2587,7 +2634,7 @@ Func BestTarget_ATouchOfGuile($a_f_AggroRange)
 	; Hex Spell. Deals 44...80 damage. Target foe cannot attack (5...7...8 seconds) if it was knocked-down.
 	; Concise description
 	; Spell. Deals 44...80 damage. Target foe cannot attack (5...7...8 seconds) if it was knocked-down.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
 EndFunc
 
 ; Skill ID: 2415 - $GC_I_SKILL_ID_ASURAN_SCAN
@@ -2601,7 +2648,7 @@ Func BestTarget_AsuranScan($a_f_AggroRange)
 	; Hex Spell. (9...12 seconds.) You cannot miss target foe. If you kill this foe, you lose 5% Death Penalty.
 	; Concise description
 	; Spell. (9...12 seconds.) You cannot miss target foe. If you kill this foe, you lose 5% Death Penalty.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2418 - $GC_I_SKILL_ID_PAIN_INVERTER
@@ -2625,7 +2672,7 @@ Func BestTarget_TongueLash($a_f_AggroRange)
 	; Hex Spell. (4 seconds.) Causes -12 Health degeneration; 25% chance to miss.
 	; Concise description
 	; Spell. (4 seconds.) Causes -12 Health degeneration; 25% chance to miss.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2503 - $GC_I_SKILL_ID_UNRELIABLE
@@ -2649,7 +2696,7 @@ Func BestTarget_TheMastersMark($a_f_AggroRange)
 	; Hex Spell. (24 seconds.) Causes -1 Health degeneration. This hex ends if target foe is hit with The Sniper's Spear.
 	; Concise description
 	; Spell. (24 seconds.) Causes -1 Health degeneration. This hex ends if target foe is hit with The Sniper's Spear.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2544 - $GC_I_SKILL_ID_TONGUE_WHIP
@@ -2663,7 +2710,7 @@ Func BestTarget_TongueWhip($a_f_AggroRange)
 	; Hex Spell. Causes knock-down (3 seconds); inflicts a Deep Wound (10 seconds).
 	; Concise description
 	; Spell. Causes knock-down (3 seconds); inflicts a Deep Wound (10 seconds).
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2546 - $GC_I_SKILL_ID_DISHONORABLE
@@ -2691,7 +2738,7 @@ Func BestTarget_ReapersMark2($a_f_AggroRange)
 	; Elite Hex Spell. (30 seconds.) Causes -1...4...5 Health degeneration. You gain 5...13...15 Energy if target foe dies while suffering from this hex.
 	; Concise description
 	; Hex Spell. (30 seconds.) Causes -1...4...5 Health degeneration. You gain 5...13...15 Energy if target foe dies while suffering from this hex.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2631 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -2702,7 +2749,7 @@ Func CanUse_SpectralAgonySaulDalessio()
 EndFunc
 
 Func BestTarget_SpectralAgonySaulDalessio($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2681 - $GC_I_SKILL_ID_SHARED_BURDEN_GWEN
@@ -2712,7 +2759,7 @@ Func CanUse_SharedBurdenGwen()
 EndFunc
 
 Func BestTarget_SharedBurdenGwen($a_f_AggroRange)
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2682 - $GC_I_SKILL_ID_SUM_OF_ALL_FEARS_GWEN
@@ -2722,7 +2769,9 @@ Func CanUse_SumOfAllFearsGwen()
 EndFunc
 
 Func BestTarget_SumOfAllFearsGwen($a_f_AggroRange)
-	Return 0
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsMoving")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2734 - $GC_I_SKILL_ID_MIND_WRACK_PVP
@@ -2732,7 +2781,7 @@ Func CanUse_MindWrackPvp()
 EndFunc
 
 Func BestTarget_MindWrackPvp($a_f_AggroRange)
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 2756 - $GC_I_SKILL_ID_MAD_KINGS_FAN
@@ -2756,7 +2805,8 @@ Func CanUse_MindFreezePvp()
 EndFunc
 
 Func BestTarget_MindFreezePvp($a_f_AggroRange)
-	Return 0
+	; PVP variant of MindFreeze
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 2906 - $GC_I_SKILL_ID_TARGET_ACQUISITION
@@ -2766,7 +2816,11 @@ Func CanUse_TargetAcquisition()
 EndFunc
 
 Func BestTarget_TargetAcquisition($a_f_AggroRange)
-	Return 0
+	; Description
+	; Hex Spell. Target foe is Marked and can no longer evade attacks.
+	; Concise description
+	; Spell. Target foe is Marked and can no longer evade attacks.
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2916 - $GC_I_SKILL_ID_NOX_PHANTOM
@@ -2776,7 +2830,11 @@ Func CanUse_NoxPhantom()
 EndFunc
 
 Func BestTarget_NoxPhantom($a_f_AggroRange)
-	Return 0
+	; Description
+	; Hex Spell. Launches a net. If it hits, your target is knocked down, and their movement speed is -66% for 10 seconds.
+	; Concise description
+	; Spell. Launches a net. If it hits, your target is knocked down, and their movement speed is -66% for 10 seconds.
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2937 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -2792,7 +2850,8 @@ Func CanUse_FragilityPvp()
 EndFunc
 
 Func BestTarget_FragilityPvp($a_f_AggroRange)
-	Return 0
+	; PVP variant of Fragility
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3086 - $GC_I_SKILL_ID_WEIGHT_OF_DHUUM_HEX
@@ -2802,7 +2861,8 @@ Func CanUse_WeightOfDhuumHex()
 EndFunc
 
 Func BestTarget_WeightOfDhuumHex($a_f_AggroRange)
-	Return 0
+	; Hex Spell - target lowest HP enemy
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3151 - $GC_I_SKILL_ID_EMPATHY_PVP
@@ -2812,7 +2872,10 @@ Func CanUse_EmpathyPvp()
 EndFunc
 
 Func BestTarget_EmpathyPvp($a_f_AggroRange)
-	Return 0
+	; PVP variant of Empathy - target attacking enemies for maximum effect
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3152 - $GC_I_SKILL_ID_CRIPPLING_ANGUISH_PVP
@@ -2822,7 +2885,10 @@ Func CanUse_CripplingAnguishPvp()
 EndFunc
 
 Func BestTarget_CripplingAnguishPvp($a_f_AggroRange)
-	Return 0
+	; PVP variant of CripplingAnguish
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3182 - $GC_I_SKILL_ID_PANIC_PVP
@@ -2832,7 +2898,8 @@ Func CanUse_PanicPvp()
 EndFunc
 
 Func BestTarget_PanicPvp($a_f_AggroRange)
-	Return 0
+	; PVP variant of Panic
+	Return UAI_GetBestAOETarget(-2, 1320, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3183 - $GC_I_SKILL_ID_MIGRAINE_PVP
@@ -2842,7 +2909,8 @@ Func CanUse_MigrainePvp()
 EndFunc
 
 Func BestTarget_MigrainePvp($a_f_AggroRange)
-	Return 0
+	; PVP variant of Migraine
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 3186 - $GC_I_SKILL_ID_SHARED_BURDEN_PVP
@@ -2852,7 +2920,8 @@ Func CanUse_SharedBurdenPvp()
 EndFunc
 
 Func BestTarget_SharedBurdenPvp($a_f_AggroRange)
-	Return 0
+	; PVP variant of SharedBurden
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3187 - $GC_I_SKILL_ID_STOLEN_SPEED_PVP

--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Skill10.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Skill10.au3
@@ -14,7 +14,8 @@ Func BestTarget_Blackout($a_f_AggroRange)
 	; Skill. For 2...5...6 seconds, all of touched target foe's skills are disabled, and all of your skills are disabled for 5 seconds.
 	; Concise description
 	; Touch Skill. (2...5...6 seconds.) Disables skills. Your skills are disabled (5 seconds).
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 154 - $GC_I_SKILL_ID_PLAGUE_TOUCH
@@ -27,7 +28,8 @@ Func BestTarget_PlagueTouch($a_f_AggroRange)
 	; Skill. Transfer 1...3...3 negative condition[s] and [its/their] remaining duration[s] from yourself to target touched foe.
 	; Concise description
 	; Touch Skill. Transfers 1...3...3 condition[s] from yourself to target foe.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 155 - $GC_I_SKILL_ID_VILE_TOUCH
@@ -40,7 +42,8 @@ Func BestTarget_VileTouch($a_f_AggroRange)
 	; Skill. Touch target foe to deal 20...56...65 damage.
 	; Concise description
 	; Touch Skill. Deals 20...56...65 damage.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 156 - $GC_I_SKILL_ID_VAMPIRIC_TOUCH
@@ -68,7 +71,8 @@ Func BestTarget_TouchOfAgony($a_f_AggroRange)
 	; Skill. Target touched foe takes 20...50...58 shadow damage.
 	; Concise description
 	; Touch Skill. Deals 20...50...58 damage.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 231 - $GC_I_SKILL_ID_SHOCK
@@ -81,7 +85,8 @@ Func BestTarget_Shock($a_f_AggroRange)
 	; Skill. Target touched foe is knocked down and struck for 10...50...60 lightning damage. This skill has 25% armor penetration.
 	; Concise description
 	; Touch Skill. Deals 10...50...60 lightning damage. Causes knock-down. 25% armor penetration.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 232 - $GC_I_SKILL_ID_LIGHTNING_TOUCH
@@ -94,7 +99,8 @@ Func BestTarget_LightningTouch($a_f_AggroRange)
 	; Skill. Target touched foe and all adjacent foes are struck for 10...50...60 lightning damage, are Blinded for 1...3...4 second[s], and have Cracked Armor for 1...8...10 second[s]. This skill has 25% armor penetration.
 	; Concise description
 	; Touch Skill. Deals 10...50...60 lightning damage. Also hits foes adjacent to target foe. Inflicts Blind (1...3...4 second[s]) and Cracked Armor (1...8...10 second[s]) on all struck foes. 25% armor penetration.
-	Return 0
+	; Target: Grouped enemies (AOE touch skill)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 300 - $GC_I_SKILL_ID_CONTEMPLATION_OF_PURITY
@@ -120,7 +126,8 @@ Func BestTarget_HolyStrike($a_f_AggroRange)
 	; Skill. Touched target foe takes 10...46...55 holy damage. If knocked down, your target takes an additional 10...46...55 holy damage.
 	; Concise description
 	; Touch Skill. Deals 10...46...55 holy damage. Deals 10...46...55 more holy damage if target is knocked down.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 389 - $GC_I_SKILL_ID_FLOURISH
@@ -146,6 +153,8 @@ Func BestTarget_CharmAnimal($a_f_AggroRange)
 	; Skill. Charm target animal. Once charmed, your animal companion will travel with you whenever you have Charm Animal equipped. You cannot charm an animal that is more than 4 levels above you.
 	; Concise description
 	; Skill. Charm target animal. Once charmed, your animal companion will travel with you whenever you have Charm Animal equipped. You cannot charm an animal that is more than 4 levels above you.
+	; Target: Nearest animal (special targeting)
+	; Note: This would need an animal filter to work properly
 	Return 0
 EndFunc
 
@@ -172,7 +181,8 @@ Func BestTarget_ThrowDirt($a_f_AggroRange)
 	; Skill. Target touched foe and foes adjacent to your target become Blinded for 3...13...15 seconds.
 	; Concise description
 	; Touch Skill. Inflicts Blindness condition (3...13...15 seconds). Also affects foes adjacent to target foe.
-	Return 0
+	; Target: Grouped enemies (AOE touch skill)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 436 - $GC_I_SKILL_ID_COMFORT_ANIMAL
@@ -357,7 +367,8 @@ Func BestTarget_SpectralAgony($a_f_AggroRange)
 	; This article is about the Monster skill. For the temporarily available Bonus Mission Pack skill, see Spectral Agony (Saul D'Alessio).
 	; Concise description
 	; green; font-weight: bold;">1...30
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 565 - $GC_I_SKILL_ID_CLAIM_RESOURCE
@@ -410,7 +421,12 @@ Func BestTarget_IronPalm($a_f_AggroRange)
 	; Skill. Target touched foe suffers 5...41...50 damage, and if that foe is suffering from a hex or condition that foe is knocked down. Iron Palm counts as a lead attack.
 	; Concise description
 	; Touch Skill. Deals 5...41...50 damage. Causes knock-down if target foe is hexed or has a condition. Counts as a lead attack.
-	Return 0
+	; Target: Conditioned/hexed enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	$l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 810 - $GC_I_SKILL_ID_PROTECTORS_DEFENSE
@@ -432,7 +448,10 @@ Func BestTarget_ExpungeEnchantments($a_f_AggroRange)
 	; Skill. Target foe loses 1 enchantment. All of your other non-attack skills are disabled for 10...6...5 seconds. For each skill disabled in this way, target touched foe loses 1 additional enchantment.
 	; Concise description
 	; Touch Skill. Removes one enchantment for each non-attack skill you have. All your non-attack skills are disabled (10...6...5 seconds).
-	Return 0
+	; Target: Enchanted enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1033 - $GC_I_SKILL_ID_IMPALE
@@ -445,7 +464,8 @@ Func BestTarget_Impale($a_f_AggroRange)
 	; Skill. Must follow a dual attack. Target foe is struck for 25...85...100 earth damage and suffers from a Deep Wound for 5...17...20 seconds.
 	; Concise description
 	; Skill. Deals 25...85...100 earth damage. Inflicts Deep Wound condition (5...17...20 seconds). Must follow a dual attack.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1039 - $GC_I_SKILL_ID_STAR_STRIKE
@@ -471,7 +491,8 @@ Func BestTarget_PalmStrike($a_f_AggroRange)
 	; Elite Skill. Target touched foe takes 10...54...65 damage and is Crippled for 1...4...5 second[s]. This skill counts as an off-hand attack.
 	; Concise description
 	; Elite Touch Skill. Deals 10...54...65 damage and inflicts Crippled condition (1...4...5 second[s]). This skill counts as an off-hand attack.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1072 - $GC_I_SKILL_ID_STAR_SERVANT
@@ -497,7 +518,8 @@ Func BestTarget_VampiricBite($a_f_AggroRange)
 	; Skill. Touch target foe to steal up to 29...65...74 Health.
 	; Concise description
 	; Touch Skill. Steals 29...65...74 Health.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1078 - $GC_I_SKILL_ID_WALLOWS_BITE
@@ -506,7 +528,8 @@ Func CanUse_WallowsBite()
 EndFunc
 
 Func BestTarget_WallowsBite($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1079 - $GC_I_SKILL_ID_ENFEEBLING_TOUCH
@@ -519,7 +542,8 @@ Func BestTarget_EnfeeblingTouch($a_f_AggroRange)
 	; Skill. Target touched foe loses 5...41...50 Health and suffers from Weakness for 5...17...20 seconds.
 	; Concise description
 	; Touch Skill. Causes 5...41...50 Health loss. Inflicts Weakness condition (5...17...20 seconds).
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1100 - $GC_I_SKILL_ID_CELESTIAL_STORM
@@ -532,7 +556,8 @@ Func BestTarget_CelestialStorm($a_f_AggroRange)
 	; Skill. Create a celestial storm at target foe's location that lasts for 15 seconds. Each second, all foes in the area take 40 fire damage, 40 cold damage, 40 lightning damage, and 40 earth damage.
 	; Concise description
 	; Skill. Deals 40 damage of each elemental type each second (15 seconds). Hits all foes in the area of target's initial location.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1124 - $GC_I_SKILL_ID_STAR_SHINE
@@ -558,7 +583,8 @@ Func BestTarget_StonesoulStrike($a_f_AggroRange)
 	; Skill. Touched target foe takes 10...46...55 holy damage. If knocked down, your target takes an additional 10...46...55 holy damage.
 	; Concise description
 	; Touch Skill. Deals 10...46...55 holy damage. Deals 10...46...55 more holy damage if target is knocked down.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1140 - $GC_I_SKILL_ID_STORM_OF_SWORDS
@@ -584,7 +610,8 @@ Func BestTarget_Shove($a_f_AggroRange)
 	; Elite Skill. Target touched foe is knocked down. If that foe was moving, that foe's stance ends and that foe takes 15...63...75 damage before being knocked down.
 	; Concise description
 	; Elite Touch Skill. Causes knockdown. Initial effect: ends foe's stance and deals 15...63...75 damage if target foe is moving.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1147 - $GC_I_SKILL_ID_BASE_DEFENSE
@@ -597,7 +624,8 @@ Func BestTarget_BaseDefense($a_f_AggroRange)
 	; Skill. All foes in range lose 999 Health and are knocked down for 5 seconds.
 	; Concise description
 	; Skill. Causes 999 Health loss and knocks down (5 seconds). Hits all foes in range.
-	Return 0
+	; Target: Self (AOE skill)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1148 - $GC_I_SKILL_ID_CARRIER_DEFENSE
@@ -636,7 +664,8 @@ Func BestTarget_JuggernautToss($a_f_AggroRange)
 	; Skill. Target touched foe takes 50 damage and is knocked down for 5 seconds.
 	; Concise description
 	; Touch Skill. 50 damage. Causes knock-down (5 seconds).
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1178 - $GC_I_SKILL_ID_LAST_STAND
@@ -667,7 +696,8 @@ Func CanUse_SiegeTurtleAttackTheEternalGrove()
 EndFunc
 
 Func BestTarget_SiegeTurtleAttackTheEternalGrove($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1187 - $GC_I_SKILL_ID_SIEGE_TURTLE_ATTACK_FORT_ASPENWOOD
@@ -676,7 +706,8 @@ Func CanUse_SiegeTurtleAttackFortAspenwood()
 EndFunc
 
 Func BestTarget_SiegeTurtleAttackFortAspenwood($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1188 - $GC_I_SKILL_ID_SIEGE_TURTLE_ATTACK_GYALA_HATCHERY
@@ -805,7 +836,8 @@ Func CanUse_ForestsBinding()
 EndFunc
 
 Func BestTarget_ForestsBinding($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1308 - $GC_I_SKILL_ID_EXPLODING_SPORES
@@ -831,7 +863,8 @@ Func BestTarget_RageOfTheSea($a_f_AggroRange)
 	; Skill. For 2 minutes, you have +4 Health regeneration, +1 Energy regeneration, and you move 33% faster.
 	; Concise description
 	; Skill. (2 minutes.) You have +4 Health regeneration, +1 Energy regeneration, and move 33% faster.
-	Return 0
+	; Target: Self (self-buff)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1316 - $GC_I_SKILL_ID_MEDITATION_OF_THE_REAPER2
@@ -854,7 +887,8 @@ Func BestTarget_TormentSlash($a_f_AggroRange)
 	; This article is about the skill used by Torment Claws. For the skill used by Smothering Tendrils, see Torment Slash (Smothering Tendrils).
 	; Concise description
 	; Related skills">edit
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1326 - $GC_I_SKILL_ID_TRADE_WINDS
@@ -867,6 +901,10 @@ Func BestTarget_TradeWinds($a_f_AggroRange)
 	; Skill. For 10 seconds, you move with the swiftness of the Canthan fleet. This enchantment may also be applied to target allies.
 	; Concise description
 	; Skill. (10 seconds.) Target ally moves with the swiftness of the Canthan fleet.
+	; Target: Lowest health ally (support spell)
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+
 	Return 0
 EndFunc
 
@@ -880,7 +918,8 @@ Func BestTarget_DragonBlast($a_f_AggroRange)
 	; Dragon Arena skill
 	; Concise description
 	; kills target foe if it hits.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1328 - $GC_I_SKILL_ID_IMPERIAL_MAJESTY
@@ -893,7 +932,8 @@ Func BestTarget_ImperialMajesty($a_f_AggroRange)
 	; Skill. Target touched foe kowtows before you and takes 80 damage.
 	; Concise description
 	; Touch Skill. Target foe kowtows before you and takes 80 damage.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1339 - $GC_I_SKILL_ID_SYMBOLS_OF_INSPIRATION
@@ -906,7 +946,8 @@ Func BestTarget_SymbolsOfInspiration($a_f_AggroRange)
 	; Elite Skill. For 1...25...31 seconds, this skill becomes the Elite of target foe. Elite spells you cast use your Fast Casting attribute instead of their normal attributes.
 	; Concise description
 	; Elite Skill. (1...25...31 seconds.) This skill becomes the Elite of target foe. Elite spells you cast use your Fast Casting attribute instead of their normal attributes.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1386 - $GC_I_SKILL_ID_SENTRY_TRAP_SKILL
@@ -963,7 +1004,8 @@ Func BestTarget_Headbutt($a_f_AggroRange)
 	; Elite Skill. Target touched foe takes 40...88...100 damage. You are Dazed for 5...17...20 seconds.
 	; Concise description
 	; Elite Touch Skill. Deals 40...88...100 damage. You are Dazed (5...17...20 seconds).
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1407 - $GC_I_SKILL_ID_LIONS_COMFORT
@@ -1084,7 +1126,8 @@ Func BestTarget_LeaveJunundu($a_f_AggroRange)
 	; Skill. The junundu releases you from its jaws.
 	; Concise description
 	; Skill. The junundu releases you from its jaws.
-	Return 0
+	; Target: Self (special skill - releases from junundu)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1445 - $GC_I_SKILL_ID_SIGNAL_FLARE
@@ -1119,7 +1162,8 @@ Func CanUse_EhzahFromAbove()
 EndFunc
 
 Func BestTarget_EhzahFromAbove($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1454 - $GC_I_SKILL_ID_CALL_TO_THE_TORMENT
@@ -1150,7 +1194,8 @@ Func CanUse_AbaddonsFavor()
 EndFunc
 
 Func BestTarget_AbaddonsFavor($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1471 - $GC_I_SKILL_ID_SCAVENGERS_FOCUS
@@ -1172,7 +1217,10 @@ Func BestTarget_Awe($a_f_AggroRange)
 	; Skill. If this skill hits a knocked-down foe, that foe becomes Dazed for 5...13...15 seconds. Awe has half the normal range.
 	; Concise description
 	; Half Range Skill. Inflicts Dazed condition (5...13...15 seconds). No effect unless target is knocked-down.
-	Return 0
+	; Target: Knocked-down enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsKnockedDown")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1583 - $GC_I_SKILL_ID_LEADERS_ZEAL
@@ -1203,6 +1251,9 @@ Func BestTarget_AngelicProtection($a_f_AggroRange)
 	; Skill. For 10 seconds, any time target other ally takes more than 250...130...100 damage per second, that ally is healed for any damage over that amount.
 	; Concise description
 	; Skill. (10 seconds.) Each second that target ally takes damage over 250...130...100, that ally is healed for any damage over that amount. Cannot self target.
+	; Target: Lowest health ally (support spell, cannot self-target)
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
 	Return 0
 EndFunc
 
@@ -1255,7 +1306,8 @@ Func BestTarget_QueenBite($a_f_AggroRange)
 	; Skill. Target touched foe is struck for 80 piercing damage.
 	; Concise description
 	; Touch Skill. Deals 80 piercing damage.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1620 - $GC_I_SKILL_ID_QUEEN_THUMP
@@ -1281,7 +1333,8 @@ Func BestTarget_QueenSiege($a_f_AggroRange)
 	; Skill. Spit a projectile at target foe. It strikes for 100 earth damage and knocks down target foe if it hits. This skill cannot be used on nearby foes.
 	; Concise description
 	; Skill. Projectile: deals 100 earth damage and causes knock-down. Cannot be used on nearby foes.
-	Return 0
+	; Target: Enemy outside nearby range (projectile skill)
+	Return UAI_GetFarthestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1643 - $GC_I_SKILL_ID_ASSAULT_ENCHANTMENTS
@@ -1294,7 +1347,10 @@ Func BestTarget_AssaultEnchantments($a_f_AggroRange)
 	; Elite Skill. Must follow a dual attack. Target foe loses all enchantments.
 	; Concise description
 	; Elite Skill. Removes all enchantments. Must follow a dual attack.
-	Return 0
+	; Target: Enchanted enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1644 - $GC_I_SKILL_ID_WASTRELS_COLLAPSE
@@ -1303,7 +1359,8 @@ Func CanUse_WastrelsCollapse()
 EndFunc
 
 Func BestTarget_WastrelsCollapse($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1645 - $GC_I_SKILL_ID_LIFT_ENCHANTMENT
@@ -1316,7 +1373,10 @@ Func BestTarget_LiftEnchantment($a_f_AggroRange)
 	; Touch Skill. If target touched foe is knocked down, that foe loses one enchantment.
 	; Concise description
 	; Touch Skill. Removes one enchantment.No [sic] effect unless target foe is knocked-down.
-	Return 0
+	; Target: Knocked-down enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsKnockedDown")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1706 - $GC_I_SKILL_ID_CORRUPT_POWER
@@ -1329,7 +1389,8 @@ Func BestTarget_CorruptPower($a_f_AggroRange)
 	; Skill. All foes take 30 damage 5 times over the next 3 seconds. Each strike also removes one stance or enchantment from each foe.
 	; Concise description
 	; Skill. All foes take 30 damage 5 times over the next 3 seconds. Each strike also removes one stance or enchantment from each foe.
-	Return 0
+	; Target: Self (AOE skill affecting all nearby foes)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1708 - $GC_I_SKILL_ID_GAZE_OF_MOAVUKAAL
@@ -1338,7 +1399,8 @@ Func CanUse_GazeOfMoavukaal()
 EndFunc
 
 Func BestTarget_GazeOfMoavukaal($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1711 - $GC_I_SKILL_ID_THE_APOCRYPHA_IS_CHANGING_TO_ANOTHER_FORM
@@ -1382,7 +1444,8 @@ Func CanUse_LightbringersGaze()
 EndFunc
 
 Func BestTarget_LightbringersGaze($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1818 - $GC_I_SKILL_ID_MADDENED_STRIKE
@@ -1395,7 +1458,8 @@ Func BestTarget_MaddenedStrike($a_f_AggroRange)
 	; Skill. The maddened spirit touches you and drains away 700 Health.
 	; Concise description
 	; Touch Skill. The maddened spirit drains away 700 Health.
-	Return 0
+	; Target: Self (special skill - maddened spirit drains player)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1855 - $GC_I_SKILL_ID_KOURNAN_SIEGE
@@ -1408,7 +1472,8 @@ Func BestTarget_KournanSiege($a_f_AggroRange)
 	; Skill. A signal flare is fired into the air to summon siege fire from any nearby garrisons. Every 3 seconds for 12 seconds, targets hit by the siege fire take 40 damage and are interrupted. This skill is easily interrupted.
 	; Concise description
 	; Skill. (12 seconds.) A signal flare is fired into the air to summon siege fire from any nearby garrisons. Every 3 seconds, targets hit by the siege fire take 40 damage and are interrupted. Easily interrupted.
-	Return 0
+	; Target: Self (AOE skill - signal flare)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1861 - $GC_I_SKILL_ID_CHOKING_BREATH
@@ -1510,7 +1575,8 @@ Func BestTarget_WordsOfMadness($a_f_AggroRange)
 	; This article is about Abaddon's skill. For skill used by Qwytzylkak, see Words of Madness (Qwytzylkak).
 	; Concise description
 	; Notes">edit
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1876 - $GC_I_SKILL_ID_UNKNOWN_JUNUNDU_ABILITY
@@ -1523,7 +1589,8 @@ Func BestTarget_UnknownJununduAbility($a_f_AggroRange)
 	; Elite Skill. You have not taught your junundu to perform this skill.
 	; Concise description
 	; Elite Skill. You have not taught your junundu to perform this skill.
-	Return 0
+	; Target: Self (placeholder skill)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1880 - $GC_I_SKILL_ID_TORMENT_SLASH_SMOTHERING_TENDRILS
@@ -1532,7 +1599,8 @@ Func CanUse_TormentSlashSmotheringTendrils()
 EndFunc
 
 Func BestTarget_TormentSlashSmotheringTendrils($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1884 - $GC_I_SKILL_ID_CONSUME_TORMENT
@@ -1571,7 +1639,8 @@ Func BestTarget_TouchOfAaaaarrrrrrggghhh($a_f_AggroRange)
 	; Skill. Target foe's attributes are set to 0 for 20 seconds, and target foe and another random foe swap positions.
 	; Concise description
 	; Skill. (20 seconds.) Target foe's attributes are set to 0. This foe and another random foe swap positions.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1900 - $GC_I_SKILL_ID_SIDE_STEP
@@ -1715,7 +1784,8 @@ Func CanUse_CharrSiegeAttackWhatMustBeDone()
 EndFunc
 
 Func BestTarget_CharrSiegeAttackWhatMustBeDone($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1944 - $GC_I_SKILL_ID_CHARR_SIEGE_ATTACK_AGAINST_THE_CHARR
@@ -1737,7 +1807,8 @@ Func BestTarget_Grapple($a_f_AggroRange)
 	; Skill. You and target touched foe are knocked down. You lose your current stance.
 	; Concise description
 	; Touch Skill. Causes knockdown. You are also knocked down. Your current stance ends.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2078 - $GC_I_SKILL_ID_BERSERK
@@ -1763,7 +1834,8 @@ Func BestTarget_Chomp($a_f_AggroRange)
 	; Skill. Caster gains 500 Health after destroying target touched smaller creature.
 	; Concise description
 	; Touch Skill. Gain 500 Health. Destroy target smaller creature.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2081 - $GC_I_SKILL_ID_TWISTING_JAWS
@@ -1776,7 +1848,8 @@ Func BestTarget_TwistingJaws($a_f_AggroRange)
 	; Skill. Creature steals 120 Health from target touched foe. That foe suffers from a Deep Wound and begins Bleeding for 10 seconds.
 	; Concise description
 	; Touch Skill. Steals 120 Health; inflicts a Deep Wound and Bleeding (10 seconds).
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2088 - $GC_I_SKILL_ID_TRAMPLE
@@ -1789,7 +1862,8 @@ Func BestTarget_Trample($a_f_AggroRange)
 	; Skill. Target touched foe and all adjacent foes are knocked down and struck for 80 damage.
 	; Concise description
 	; Touch Skill. Deals 80 damage; causes knock-down. Also hits adjacent foes.
-	Return 0
+	; Target: Grouped enemies (AOE touch skill)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2103 - $GC_I_SKILL_ID_NECROSIS
@@ -1837,7 +1911,8 @@ Func CanUse_UrsanStrikeBloodWashesBlood()
 EndFunc
 
 Func BestTarget_UrsanStrikeBloodWashesBlood($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2115 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -1851,7 +1926,8 @@ Func BestTarget_Firebomb($a_f_AggroRange)
 	; Skill. Launch a slow-moving firebomb at this foe. This skill cannot recharge slower than normal.
 	; Concise description
 	; Skill. Launch a slow-moving firebomb at this foe. This skill cannot recharge slower than normal.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2119 - $GC_I_SKILL_ID_SHIELD_OF_FIRE
@@ -1873,7 +1949,8 @@ Func CanUse_VolfenClawCurseOfTheNornbear()
 EndFunc
 
 Func BestTarget_VolfenClawCurseOfTheNornbear($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2130 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -1945,6 +2022,9 @@ Func BestTarget_VitalityTransfer($a_f_AggroRange)
 	; Skill. Target ally is healed for 100 Health, and the nearest foe takes 100 damage.
 	; Concise description
 	; Skill. Heals target ally for 100; the nearest foe takes 100 damage.
+	; Target: Lowest health ally (support spell)
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
+	If $l_i_Target <> 0 Then Return $l_i_Target
 	Return 0
 EndFunc
 
@@ -1954,7 +2034,8 @@ Func CanUse_EnergyBlastGolem()
 EndFunc
 
 Func BestTarget_EnergyBlastGolem($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2160 - $GC_I_SKILL_ID_CHAOTIC_ENERGY
@@ -1967,7 +2048,8 @@ Func BestTarget_ChaoticEnergy($a_f_AggroRange)
 	; Skill. 5 chaotic Energy sources strike up to 5 foes and deal 125 damage per strike.
 	; Concise description
 	; Skill. 5 chaotic energy sources strike up to 5 foes and deal 125 damage per strike.
-	Return 0
+	; Target: Self (AOE skill)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2168 - $GC_I_SKILL_ID_RAVEN_BLESSING_A_GATE_TOO_FAR
@@ -1986,7 +2068,8 @@ Func CanUse_RavenTalonsAGateTooFar()
 EndFunc
 
 Func BestTarget_RavenTalonsAGateTooFar($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2174 - $GC_I_SKILL_ID_ASPECT_OF_OAK
@@ -2011,8 +2094,9 @@ Func BestTarget_SunderingSoulcrush($a_f_AggroRange)
 	; Description
 	; Monster skill
 	; Concise description
-	; "en","wgPageContentModel":"wikitext","wgRelevantPageName":"Sundering_Soulcrush","wgRelevantArticleId":230854,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgMFDisplayWikibaseDescriptions":{"search":false,"nearby":false,"watchlist":false,"tagline":false},"wgPopupsFlags":4,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true}; RLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready","user.options":"loading","skins.monobook.styles":"ready"};RLPAGEMODULES=["site","mediawiki.page.ready","skins.monobook.scripts","mmv.head","mmv.bootstrap.autostart","ext.popups"];
-	Return 0
+	; Notes">edit
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2180 - $GC_I_SKILL_ID_PYROCLASTIC_SHOT
@@ -2025,7 +2109,8 @@ Func BestTarget_PyroclasticShot($a_f_AggroRange)
 	; Skill. Pyroclastic fragments spew forth, dealing 80 damage to target foe and all adjacent foes. Affected foes are Crippled and begin Burning for 7 seconds. This skill causes any powder keg in target's hands to explode.
 	; Concise description
 	; Skill. Projectile: deals 80 damage and inflicts Burning and Crippled conditions (7 seconds) on target and adjacent foes. Causes any powder keg in target's hands to explode.
-	Return 0
+	; Target: Grouped enemies (AOE projectile)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2181 - $GC_I_SKILL_ID_EXPLOSIVE_FORCE
@@ -2077,6 +2162,9 @@ Func BestTarget_InspirationalSpeech($a_f_AggroRange)
 	; Skill. You lose all adrenaline and target other ally gains 1...3...4 strikes of adrenaline.
 	; Concise description
 	; Skill. Target ally gains 1...3...4 strike[s] of adrenaline. Cannot self-target. You lose all adrenaline.
+	; Target: Lowest health ally (support spell, cannot self-target)
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
 	Return 0
 EndFunc
 
@@ -2090,7 +2178,8 @@ Func BestTarget_EarBite($a_f_AggroRange)
 	; Skill. Target touched foe takes 50...70 piercing damage and begins Bleeding for 15...25 seconds.
 	; Concise description
 	; Touch Skill. Deals 50...70 piercing damage and inflicts Bleeding condition (15...25 seconds).
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2214 - $GC_I_SKILL_ID_LOW_BLOW
@@ -2103,7 +2192,10 @@ Func BestTarget_LowBlow($a_f_AggroRange)
 	; Skill. Strike target foe for 45...70 damage. If target foe is knocked down, that foe takes an additional 30...50 damage and suffers from Cracked Armor for 14...20 seconds.
 	; Concise description
 	; Touch Skill. Deals 45...70 damage. Inflicts 30...50 damage and Cracked Armor (14...20 seconds) if target foe is knocked down.
-	Return 0
+	; Target: Knocked-down enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsKnockedDown")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2215 - $GC_I_SKILL_ID_BRAWLING_HEADBUTT
@@ -2116,7 +2208,8 @@ Func BestTarget_BrawlingHeadbutt($a_f_AggroRange)
 	; This article is about the Deldrimor skill. For the brawling skill with the same name, see Brawling Headbutt (Brawling skill).
 	; Concise description
 	; green; font-weight: bold;">45...70
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2241 - $GC_I_SKILL_ID_GELATINOUS_CORPSE_CONSUMPTION
@@ -2168,7 +2261,8 @@ Func BestTarget_UnstableOozeExplosion($a_f_AggroRange)
 	; Monster
 	; Concise description
 	; Related skills">edit
-	Return 0
+	; Target: Self (AOE skill)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2246 - $GC_I_SKILL_ID_UNSTABLE_AURA
@@ -2207,7 +2301,8 @@ Func BestTarget_SearingBreath($a_f_AggroRange)
 	; Skill. The Great Destroyer breathes a cone of fire that hits foes for 80 fire damage and 40 more fire damage for each enchantment on them. All Destroyers in the affected area are healed for 80 Health.
 	; Concise description
 	; Skill. A cone of fire deals 80 fire damage and 40 more fire damage for each enchantment on struck foes. All Destroyers in the cone's area are healed for 80.
-	Return 0
+	; Target: Self (AOE skill - cone of fire)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2333 - $GC_I_SKILL_ID_BRAWLING
@@ -2246,7 +2341,8 @@ Func BestTarget_FlameJet($a_f_AggroRange)
 	; Skill. A jet of lava shoots out to target foe dealing 600 damage. If that foe is under the effects of an enchantment, the damage is halved.
 	; Concise description
 	; Skill. Deals 600 damage. Half that damage if target is enchanted.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2346 - $GC_I_SKILL_ID_LAVA_GROUND
@@ -2326,7 +2422,8 @@ Func CanUse_TalonStrike()
 EndFunc
 
 Func BestTarget_TalonStrike($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2364 - $GC_I_SKILL_ID_LAVA_BLAST
@@ -2361,7 +2458,8 @@ Func BestTarget_UrsanStrike($a_f_AggroRange)
 	; Skill. You deal 40...75 damage, and 40...75 slashing damage to target touched foe.
 	; Concise description
 	; Touch Skill. Deals 40...75 damage, and 40...75 slashing damage.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2376 - $GC_I_SKILL_ID_URSAN_RAGE
@@ -2374,7 +2472,8 @@ Func BestTarget_UrsanRage($a_f_AggroRange)
 	; Skill. Touch target foe and deal 60...135 physical damage to all adjacent enemies. Struck foes are also knocked down for 2 seconds.
 	; Concise description
 	; Touch Skill. Deals 60...135 physical damage. Causes knock-down. Hits foes adjacent to you.
-	Return 0
+	; Target: Grouped enemies (AOE touch skill)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2380 - $GC_I_SKILL_ID_VOLFEN_CLAW
@@ -2387,7 +2486,8 @@ Func BestTarget_VolfenClaw($a_f_AggroRange)
 	; Skill. You deal 40...60 damage and target touched foe suffers from Deep Wound for 2...5 seconds.
 	; Concise description
 	; Touch Skill. Deals 40...60 damage. Inflicts Deep Wound condition (2...5 seconds.)
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2385 - $GC_I_SKILL_ID_RAVEN_TALONS
@@ -2400,7 +2500,8 @@ Func BestTarget_RavenTalons($a_f_AggroRange)
 	; Skill. Target touched foe takes 20...35 piercing damage and is Bleeding and Crippled for 4...10 seconds.
 	; Concise description
 	; Touch Skill. Deals 20...35 piercing damage. Inflicts Bleeding and Crippled conditions (4...10 seconds).
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2389 - $GC_I_SKILL_ID_TOTEM_OF_MAN
@@ -2545,7 +2646,8 @@ Func BestTarget_Gloat($a_f_AggroRange)
 	; Skill. After killing an enemy, all Charr within earshot gain 10 Energy and 5 adrenaline.
 	; Concise description
 	; Skill. After killing an enemy, all Charr within earshot gain 10 Energy and 5 adrenaline.
-	Return 0
+	; Target: Self (passive skill - triggers after kill)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2484 - $GC_I_SKILL_ID_METAMORPHOSIS
@@ -2610,7 +2712,9 @@ Func BestTarget_OozeCombination($a_f_AggroRange)
 	; Skill. Combine with target touched ooze.
 	; Concise description
 	; Touch Skill. Combine with another Ooze.
-	Return 0
+	; Target: Nearest ooze (special targeting - would need ooze filter)
+	; For now, target nearest living creature
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2493 - $GC_I_SKILL_ID_OOZE_DIVISION
@@ -2684,7 +2788,10 @@ Func BestTarget_SoulrendingShriek($a_f_AggroRange)
 	; Skill. Target foe takes 40 damage. If target is enchanted, that foe loses one enchantment and is Dazed for 8 seconds.
 	; Concise description
 	; Skill. 40 damage. Removes one enchantment and inflicts Dazed condition (8 seconds) if target foe is enchanted.
-	Return 0
+	; Target: Enchanted enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2505 - $GC_I_SKILL_ID_SIEGE_DEVOURER_FEAST
@@ -2709,8 +2816,9 @@ Func BestTarget_DevourerBite($a_f_AggroRange)
 	; Description
 	; Devourer skill
 	; Concise description
-	; 20251201190305 Cache expiry: 86400 Reduced expiry: false Complications: [] CPU time usage: 0.016 seconds Real time usage: 0.028 seconds Preprocessor visited node count: 282/1000000 Post‐expand include size: 2278/2097152 bytes Template argument size: 494/2097152 bytes Highest expansion depth: 7/100 Expensive parser function count: 0/100 Unstrip recursion depth: 0/20 Unstrip post‐expand size: 0/5000000 bytes ExtLoops count: 0/1000 -->
-	Return 0
+	; Notes">edit
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2507 - $GC_I_SKILL_ID_SIEGE_DEVOURER_SWIPE
@@ -2736,7 +2844,8 @@ Func BestTarget_DevourerSiege($a_f_AggroRange)
 	; Skill. Launch two projectiles at target foe's location. Foes near that location are struck for 150 fire damage and knocked down. This skill cannot target a foe near you.
 	; Concise description
 	; Skill. Two projectiles: deal 150 fire damage; causes knock-down. Hits foes near target. Cannot target foes near you.
-	Return 0
+	; Target: Enemy outside nearby range (projectile skill)
+	Return UAI_GetFarthestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2513 - $GC_I_SKILL_ID_DISMOUNT_SIEGE_DEVOURER
@@ -2762,7 +2871,8 @@ Func BestTarget_Mount($a_f_AggroRange)
 	; "Mount" redirects here. For temporary skills acquired in mount forms, see List of temporary skills#Mount skills.
 	; Concise description
 	; Notes">edit
-	Return 0
+	; Target: Self (mount skill)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2518 - $GC_I_SKILL_ID_TENGUS_GAZE
@@ -2843,7 +2953,8 @@ Func BestTarget_ThrowRock($a_f_AggroRange)
 	; Skill. Throw a rock at your target. If it strikes a foe, that foe is knocked down and becomes Crippled for 10 seconds.
 	; Concise description
 	; Skill. Throw a rock at your target, causing knockdown and inflicting Crippled condition (10 seconds.)
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2662 - $GC_I_SKILL_ID_NIGHTMARISH_AURA
@@ -2869,7 +2980,8 @@ Func BestTarget_SiegeStrike($a_f_AggroRange)
 	; Skill. Target foe is struck for 200 damage and knocked down.
 	; Concise description
 	; Skill. Deals 200 damage and causes knockdown.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2665 - $GC_I_SKILL_ID_BARBED_BOMB
@@ -2980,12 +3092,14 @@ Func CanUse_AncestorsRagePvP()
 EndFunc
 
 Func BestTarget_AncestorsRagePvP($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2894 - $GC_I_SKILL_ID_BAMPH_LITE
 Func BestTarget_BamphLite($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2903 - $GC_I_SKILL_ID_REACTOR_BLAST_TIMER
@@ -3033,7 +3147,8 @@ Func CanUse_NoxLockOn()
 EndFunc
 
 Func BestTarget_NoxLockOn($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2926 - $GC_I_SKILL_ID_BAMPH_LIFESTEAL
@@ -3042,7 +3157,8 @@ Func BestTarget_BamphLifesteal($a_f_AggroRange)
 	; Skill. Bamph Lifesteal
 	; Concise description
 	; Skill. Bamph Lifesteal
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2931 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -3053,7 +3169,8 @@ Func CanUse_DelayedBlastBamph()
 EndFunc
 
 Func BestTarget_DelayedBlastBamph($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3000 - $GC_I_SKILL_ID_GUNTHERS_GAZE
@@ -3098,7 +3215,8 @@ Func CanUse_CharmAnimalCodex()
 EndFunc
 
 Func BestTarget_CharmAnimalCodex($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3083 - $GC_I_SKILL_ID_TOUCH_OF_DHUUM
@@ -3111,7 +3229,8 @@ Func BestTarget_TouchOfDhuum($a_f_AggroRange)
 	; Skill. Steal 100 Health from target touched foe. That foe receives 15% Death Penalty. If Touch of Dhuum steals health from a foe with 60% Death Penalty, that foe dies.
 	; Concise description
 	; Touch Skill. Steal 100 Health from target foe. That foe receives 15% Death Penalty. If Touch of Dhuum steals health from a foe with 60% Death Penalty, that foe dies.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3144 - $GC_I_SKILL_ID_HEAL_AS_ONE_PvP
@@ -3161,6 +3280,9 @@ Func BestTarget_SacrificePawn($a_f_AggroRange)
 	; Skill. Drains the life of target ally, killing them and healing the caster for an amount equal to that ally's current Health.
 	; Concise description
 	; Skill. Kills target ally. Caster gains Health equal to that ally's current Health.
+	; Target: Lowest health ally (support spell - sacrifices ally)
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
 	Return 0
 EndFunc
 
@@ -3198,7 +3320,8 @@ Func BestTarget_DamageAssessment($a_f_AggroRange)
 	; Skill. You lose all conditions. Shadowstep directly away from target enemy.
 	; Concise description
 	; Skill. You lose all conditions. Shadowstep directly away from target enemy.
-	Return 0
+	; Target: Nearest enemy (shadowstep away from them)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3305 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -3212,7 +3335,8 @@ Func BestTarget_SmashOfTheTitans($a_f_AggroRange)
 	; Remove all enchantments from target foe. All adjacent foes are knocked down and struck for 150 damage.
 	; Concise description
 	; Touch Skill. Target foe loses all Enchantments. All Adjacent Foes are Knocked Down and struck for 150 damage. [sic]
-	Return 0
+	; Target: Grouped enemies (AOE touch skill)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3384 - $GC_I_SKILL_ID_ANNIHILATOR_TOSS
@@ -3225,7 +3349,8 @@ Func BestTarget_AnnihilatorToss($a_f_AggroRange)
 	; Skill. Throw target touched foe into lava. Only works near a suitably hot lava pit.
 	; Concise description
 	; Touch Skill. Throw target into lava. Only works near very hot lava.
-	Return 0
+	; Target: Nearest enemy (touch skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3402 - $GC_I_SKILL_ID_TONIC_TIPSINESS
@@ -3268,6 +3393,7 @@ Func BestTarget_ShadowTheft($a_f_AggroRange)
 	; Elite Skill. Shadow Step to target foe. For 5...17...20 seconds that foe's attributes are reduced by 1...4...5 and your attributes are increased by 1...4...5. This skill counts as a Lead Attack. PvE Skill
 	; Concise description
 	; Elite Skill. Shadow Step to target foe. For 5...17...20 seconds that foe's attributes are reduced by 1...4...5 and your attributes are increased by 1...4...5. Counts as a Lead Attack. PvE Skill
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 

--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Skill16.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Skill16.au3
@@ -211,6 +211,7 @@ Func BestTarget_RageOfTheNtouka($a_f_AggroRange)
 	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
+
 ; Skill ID: 1508 - $GC_I_SKILL_ID_EXTEND_ENCHANTMENTS
 Func CanUse_ExtendEnchantments()
 	If UAI_PlayerHasEffect($GC_I_SKILL_ID_EXTEND_ENCHANTMENTS) Then Return False

--- a/API/Plugins/UtilityAI/Skills/UtilityAI_Spell.au3
+++ b/API/Plugins/UtilityAI/Skills/UtilityAI_Spell.au3
@@ -55,7 +55,10 @@ Func BestTarget_PowerBlock($a_f_AggroRange)
 	; Elite Spell. If target foe is casting a spell or chant, that skill and all skills of the same attribute are disabled for 1...10...12 seconds and that skill is interrupted.
 	; Concise description
 	; Elite Spell. If target foe is casting a spell or chant, that skill and all skills of the same attribute are disabled (1...10...12 seconds) and that skill is interrupted.
-	Return 0
+	; Target: Casting enemy (highest priority), fallback to nearest caster
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
 EndFunc
 
 ; Skill ID: 21 - $GC_I_SKILL_ID_INSPIRED_ENCHANTMENT
@@ -83,7 +86,8 @@ Func BestTarget_InspiredHex($a_f_AggroRange)
 	; Spell. Remove a hex from target ally and gain 4...9...10 Energy. For 20 seconds, Inspired Hex is replaced with the hex that was removed.
 	; Concise description
 	; Spell. Removes a hex from target ally. Removal effects: you gain 4...9...10 Energy; this spell is replaced with that hex (20 seconds).
-	Return 0
+	; Target: Hexed ally (support spell)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsHexed")
 EndFunc
 
 ; Skill ID: 23 - $GC_I_SKILL_ID_POWER_SPIKE
@@ -97,7 +101,8 @@ Func BestTarget_PowerSpike($a_f_AggroRange)
 	; Spell. If target foe is casting a spell or a chant, that skill is interrupted and target foe takes 30...102...120 damage.
 	; Concise description
 	; Spell. Interrupts a spell or chant. Interruption effect: deals 30...102...120 damage.
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 24 - $GC_I_SKILL_ID_POWER_LEAK
@@ -111,7 +116,8 @@ Func BestTarget_PowerLeak($a_f_AggroRange)
 	; Spell. If target foe is casting a spell or chant, that skill is interrupted and target foe loses 3...14...17 Energy.
 	; Concise description
 	; Spell. Interrupts a spell or chant. Interruption effect: causes 3...14...17 Energy loss.
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 25 - $GC_I_SKILL_ID_POWER_DRAIN
@@ -229,7 +235,10 @@ Func BestTarget_EnergyBurn($a_f_AggroRange)
 	; Spell. Target foe loses 1...8...10 Energy and takes 9 damage for each point of Energy lost.
 	; Concise description
 	; Spell. Causes 1...8...10 Energy loss. Deals 9 damage for each point of Energy lost.
-	Return 0
+	; Target: Highest health caster (energy drain effectiveness)
+	Local $l_i_Target = UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 57 - $GC_I_SKILL_ID_CRY_OF_FRUSTRATION
@@ -243,7 +252,8 @@ Func BestTarget_CryOfFrustration($a_f_AggroRange)
 	; "CoF" and "Cof" redirects here. For the dungeon, see Cathedral of Flames.
 	; Concise description
 	; green; font-weight: bold;">15...63...75
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 64 - $GC_I_SKILL_ID_MIMIC
@@ -257,7 +267,8 @@ Func BestTarget_Mimic($a_f_AggroRange)
 	; Mesmer
 	; Concise description
 	; #808080;">Ends after one use.
-	Return 0
+	; Target: Self (mimics target's elite skill)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 65 - $GC_I_SKILL_ID_ARCANE_MIMICRY
@@ -271,7 +282,8 @@ Func BestTarget_ArcaneMimicry($a_f_AggroRange)
 	; "AM" redirects here. For the mission, see Abaddon's Mouth.
 	; Concise description
 	; #808080;">Cannot self-target. No effect if target's elite skill is a form.
-	Return 0
+	; Target: Nearest enemy (mimics their elite skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 67 - $GC_I_SKILL_ID_SHATTER_HEX
@@ -285,7 +297,8 @@ Func BestTarget_ShatterHex($a_f_AggroRange)
 	; Spell. Remove a hex from target ally. If a hex is removed, foes near that ally take 30...102...120 damage.
 	; Concise description
 	; Spell. Removes a hex from target ally. Removal effect: deals 30...102...120 damage to foes near this ally.
-	Return 0
+	; Target: Hexed ally (support spell)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsHexed")
 EndFunc
 
 ; Skill ID: 68 - $GC_I_SKILL_ID_DRAIN_ENCHANTMENT
@@ -314,7 +327,8 @@ Func BestTarget_ShatterEnchantment($a_f_AggroRange)
 	; Spell. Remove an enchantment from target foe. If an enchantment is removed, that foe takes 14...83...100 damage.
 	; Concise description
 	; Spell. Removes an enchantment from target foe. Removal effect: deals 14...83...100 damage.
-	Return 0
+	; Target: Enchanted enemy (highest priority)
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
 EndFunc
 
 ; Skill ID: 77 - $GC_I_SKILL_ID_CHAOS_STORM
@@ -342,7 +356,10 @@ Func BestTarget_Epidemic($a_f_AggroRange)
 	; Spell. Spread all negative conditions and their remaining durations from target foe to all foes adjacent to your target.
 	; Concise description
 	; Spell. Conditions on target foe transfer to adjacent foes.
-	Return 0
+	; Target: Conditioned enemy with grouped enemies nearby
+	Local $l_i_Target = UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 79 - $GC_I_SKILL_ID_ENERGY_DRAIN
@@ -406,7 +423,10 @@ Func BestTarget_ArcaneThievery($a_f_AggroRange)
 	; Spell. For 5...29...35 seconds, one random spell is disabled for target foe, and Arcane Thievery is replaced by that spell.
 	; Concise description
 	; Spell. (5...29...35 seconds.) Disables one random spell. This skill becomes that spell.
-	Return 0
+	; Target: Caster enemy (highest priority)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 83 - $GC_I_SKILL_ID_ANIMATE_BONE_HORROR
@@ -458,7 +478,8 @@ Func CanUse_GrenthsBalance()
 EndFunc
 
 Func BestTarget_GrenthsBalance($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 87 - $GC_I_SKILL_ID_VERATAS_GAZE
@@ -468,7 +489,8 @@ Func CanUse_VeratasGaze()
 EndFunc
 
 Func BestTarget_VeratasGaze($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 89 - $GC_I_SKILL_ID_DEATHLY_CHILL
@@ -482,7 +504,8 @@ Func BestTarget_DeathlyChill($a_f_AggroRange)
 	; Spell. Target foe is struck for 5...41...50 cold damage. If that foe's Health is above 50%, you deal an additional 5...41...50 shadow damage.
 	; Concise description
 	; Spell. Deals 5...41...50 cold damage. Deals 5...41...50 more damage if target foe was above 50% Health.
-	Return 0
+	; Target: Highest health enemy (bonus damage)
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 90 - $GC_I_SKILL_ID_VERATAS_SACRIFICE
@@ -562,7 +585,8 @@ Func BestTarget_ShadowStrike($a_f_AggroRange)
 	; Spell. Target foe takes 12...41...48 shadow damage. If that foe's Health is above 50%, you steal up to 12...41...48 Health.
 	; Concise description
 	; Spell. Deals 12...41...48 damage. Steal up to 12...41...48 Health if this foe was above 50% Health.
-	Return 0
+	; Target: Highest health enemy (life steal bonus)
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 105 - $GC_I_SKILL_ID_DEATHLY_SWARM
@@ -590,7 +614,8 @@ Func BestTarget_RottingFlesh($a_f_AggroRange)
 	; Spell. Target fleshy foe becomes Diseased for 10...22...25 seconds, slowly losing Health.
 	; Concise description
 	; Spell. Inflicts Diseased condition (10...22...25 seconds).
-	Return 0
+	; Target: Nearest enemy (condition application)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 107 - $GC_I_SKILL_ID_VIRULENCE
@@ -604,7 +629,8 @@ Func BestTarget_Virulence($a_f_AggroRange)
 	; Elite Spell. If target foe was already suffering from a condition, that foe suffers from Disease, Poison, and Weakness for 3...13...15 seconds.
 	; Concise description
 	; Elite Spell. Inflicts Disease, Poison, and Weakness conditions (3...13...15 seconds). No effect unless this foe already had a condition.
-	Return 0
+	; Target: Conditioned enemy (condition requirement)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsConditioned")
 EndFunc
 
 ; Skill ID: 110 - $GC_I_SKILL_ID_UNHOLY_FEAST
@@ -632,7 +658,10 @@ Func BestTarget_DesecrateEnchantments($a_f_AggroRange)
 	; Spell. Target foe and all nearby foes take 6...49...60 shadow damage and 4...17...20 shadow damage for each enchantment on them.
 	; Concise description
 	; Spell. Deals 6...49...60 damage to target and nearby foes. Deals 4...17...20 more damage for each enchantment on them.
-	Return 0
+	; Target: Grouped enchanted enemies (AOE damage)
+	Local $l_i_Target = UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 117 - $GC_I_SKILL_ID_ENFEEBLE1
@@ -642,7 +671,8 @@ Func CanUse_Enfeeble1()
 EndFunc
 
 Func BestTarget_Enfeeble1($a_f_AggroRange)
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 118 - $GC_I_SKILL_ID_ENFEEBLING_BLOOD
@@ -656,7 +686,8 @@ Func BestTarget_EnfeeblingBlood($a_f_AggroRange)
 	; Spell. Target foe and all nearby foes suffer from Weakness for 5...17...20 seconds.
 	; Concise description
 	; Spell. Inflicts Weakness condition (5...17...20 seconds) on this foe and nearby foes.
-	Return 0
+	; Target: Grouped enemies (AOE condition)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 120 - $GC_I_SKILL_ID_BLOOD_OF_THE_MASTER
@@ -680,11 +711,8 @@ Func CanUse_DarkPact()
 EndFunc
 
 Func BestTarget_DarkPact($a_f_AggroRange)
-	; Description
-	; Spell. Deal 10...40...48 shadow damage to target foe.
-	; Concise description
-	; Spell. Deals 10...40...48 damage.
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 141 - $GC_I_SKILL_ID_REND_ENCHANTMENTS
@@ -698,7 +726,8 @@ Func BestTarget_RendEnchantments($a_f_AggroRange)
 	; Spell. Remove 5...8...9 enchantments from target foe. For each Monk enchantment removed, you lose 55...31...25 Health.
 	; Concise description
 	; Spell. Removes 5...8...9 enchantments from target foe. Removal cost: you lose 55...31...25 Health for each Monk enchantment removed.
-	Return 0
+	; Target: Enchanted enemy (highest priority)
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
 EndFunc
 
 ; Skill ID: 143 - $GC_I_SKILL_ID_STRIP_ENCHANTMENT
@@ -726,7 +755,10 @@ Func BestTarget_Chilblains($a_f_AggroRange)
 	; Spell. You become Poisoned for 10 seconds. Foes in the area of your target are struck for 10...37...44 cold damage and lose 1...2...2 enchantment[s].
 	; Concise description
 	; Spell. Deals 10...37...44 cold damage to foes in the area around your target; removes 1...2...2 enchantment[s] from these foes. You are Poisoned (10 seconds).
-	Return 0
+	; Target: Grouped enemies (AOE damage and enchantment removal)
+	Local $l_i_Target = UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 146 - $GC_I_SKILL_ID_OFFERING_OF_BLOOD
@@ -754,7 +786,8 @@ Func BestTarget_PlagueSending($a_f_AggroRange)
 	; Spell. Transfer 1...3...3 negative condition[s] and [its/their] remaining duration[s] from yourself to target foe and all adjacent foes.
 	; Concise description
 	; Spell. Transfer 1...3...3 condition[s] and [its/their] remaining duration[s] from yourself to target foe and all adjacent foes.
-	Return 0
+	; Target: Grouped enemies (AOE condition transfer)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 151 - $GC_I_SKILL_ID_FEAST_OF_CORRUPTION
@@ -768,7 +801,10 @@ Func BestTarget_FeastOfCorruption($a_f_AggroRange)
 	; Elite Spell. Target foe and all adjacent foes are struck for 16...67...80 shadow damage. You steal up to 8...34...40 Health from each struck foe who is suffering from a hex.
 	; Concise description
 	; Elite Spell. Deals 16...67...80 damage to target and adjacent foes. Steal 8...34...40 Health from each hexed foe.
-	Return 0
+	; Target: Grouped hexed enemies (AOE damage and life steal)
+	Local $l_i_Target = UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 152 - $GC_I_SKILL_ID_TASTE_OF_DEATH
@@ -782,7 +818,8 @@ Func BestTarget_TasteOfDeath($a_f_AggroRange)
 	; Spell. Steal up to 100...340...400 Health from target animated undead ally.
 	; Concise description
 	; Spell. Steals 100...340...400 Health from allied undead servant.
-	Return 0
+	; Target: Self (targets own minions)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 153 - $GC_I_SKILL_ID_VAMPIRIC_GAZE
@@ -810,7 +847,8 @@ Func BestTarget_WeakenArmor($a_f_AggroRange)
 	; Spell. Target foe and foes adjacent to your target have Cracked Armor for 5...17...20 seconds.
 	; Concise description
 	; Spell. Also affects adjacent foes. Inflicts Cracked Armor condition (5...17...20 seconds).
-	Return 0
+	; Target: Grouped enemies (AOE condition)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 161 - $GC_I_SKILL_ID_LIGHTNING_STORM
@@ -824,7 +862,8 @@ Func BestTarget_LightningStorm($a_f_AggroRange)
 	; Elementalist
 	; Concise description
 	; green; font-weight: bold;">14...61...73
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 162 - $GC_I_SKILL_ID_GALE
@@ -838,7 +877,8 @@ Func BestTarget_Gale($a_f_AggroRange)
 	; Spell. Knock down target foe for 2 seconds. (50% failure chance with Air Magic 4 or less.)
 	; Concise description
 	; Spell. Causes knock-down. 50% failure chance unless Air Magic 5 or more.
-	Return 0
+	; Target: Nearest enemy (knockdown control)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 163 - $GC_I_SKILL_ID_WHIRLWIND
@@ -866,7 +906,8 @@ Func BestTarget_Eruption($a_f_AggroRange)
 	; Spell. Cause an Eruption at target foe's location. Each second for 5 seconds, foes near this location are struck for 10...34...40 earth damage and are Blinded for 10 seconds.
 	; Concise description
 	; Spell. Deals 10...34...40 earth damage each second (5 seconds). Hits foes near target's initial location. Inflicts Blindness condition (10 seconds).
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 170 - $GC_I_SKILL_ID_EARTHQUAKE
@@ -880,7 +921,8 @@ Func BestTarget_Earthquake($a_f_AggroRange)
 	; Spell. You invoke an Earthquake at target foe's location. All foes near this location are knocked down and are struck for 26...85...100 earth damage.
 	; Concise description
 	; Spell. Deals 26...85...100 earth damage. Also hits foes near target. Causes knock-down.
-	Return 0
+	; Target: Grouped enemies (AOE knockdown)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 171 - $GC_I_SKILL_ID_STONING
@@ -894,7 +936,10 @@ Func BestTarget_Stoning($a_f_AggroRange)
 	; Spell. Send out a large stone, striking target foe for 45...93...105 earth damage if it hits. If Stoning hits a foe suffering from Weakness, that foe is knocked down.
 	; Concise description
 	; Spell. Projectile: deals 45...93...105 earth damage. Causes knock-down if target foe is Weakened.
-	Return 0
+	; Target: Weakened enemy (knockdown priority)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 172 - $GC_I_SKILL_ID_STONE_DAGGERS
@@ -908,7 +953,8 @@ Func BestTarget_StoneDaggers($a_f_AggroRange)
 	; Spell. Send out two Stone Daggers. Each Stone Dagger strikes target foe for 8...28...33 earth damage if it hits. If you are Overcast, each projectile inflicts Bleeding for 1...4...5 second[s].
 	; Concise description
 	; Spell. Two projectiles: each deals 8...28...33 earth damage. If Overcast, cause Bleeding for 1...4...5 second[s].
-	Return 0
+	; Target: Nearest enemy (projectile spell)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 174 - $GC_I_SKILL_ID_AFTERSHOCK
@@ -950,7 +996,8 @@ Func BestTarget_MindBurn($a_f_AggroRange)
 	; Elite Spell. Target foe and all adjacent foes take 15...51...60 fire damage. If you have more Energy than target foe, that foe and all adjacent foes take an additional 15...51...60 fire damage and are set on fire for 1...8...10 second[s].
 	; Concise description
 	; Elite Spell. Deals 15...51...60 fire damage. If you have more energy than target foe, deals 15...51...60 more fire damage and inflicts Burning (1...8...10 second[s]). Also hits adjacent foes.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 186 - $GC_I_SKILL_ID_FIREBALL
@@ -964,7 +1011,8 @@ Func BestTarget_Fireball($a_f_AggroRange)
 	; This article is about the skill. For the effect from the Obelisk Flag Stand, see Fireball (obelisk).
 	; Concise description
 	; deals
-	Return 0
+	; Target: Lowest health enemy
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 187 - $GC_I_SKILL_ID_METEOR
@@ -978,7 +1026,8 @@ Func BestTarget_Meteor($a_f_AggroRange)
 	; Spell. Target foe and all adjacent foes are struck for 7...91...112 fire damage and knocked down.
 	; Concise description
 	; Spell. Deals 7...91...112 fire damage and causes knock-down. Also hits foes adjacent to target foe.
-	Return 0
+	; Target: Grouped enemies (AOE knockdown damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 188 - $GC_I_SKILL_ID_FLAME_BURST
@@ -1002,7 +1051,8 @@ Func CanUse_RodgortsInvocation()
 EndFunc
 
 Func BestTarget_RodgortsInvocation($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 191 - $GC_I_SKILL_ID_IMMOLATE
@@ -1016,7 +1066,8 @@ Func BestTarget_Immolate($a_f_AggroRange)
 	; Spell. Target foe is struck for 20...64...75 fire damage and is set on fire for 1...3...3 second[s].
 	; Concise description
 	; Spell. Deals 20...64...75 fire damage. Inflicts Burning condition (1...3...3 second[s]).
-	Return 0
+	; Target: Nearest enemy (single target burn)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 192 - $GC_I_SKILL_ID_METEOR_SHOWER
@@ -1044,7 +1095,8 @@ Func BestTarget_Phoenix($a_f_AggroRange)
 	; This article is about the spell. For the animal companion, see Phoenix (pet).
 	; Concise description
 	; deals
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 194 - $GC_I_SKILL_ID_FLARE
@@ -1144,7 +1196,8 @@ Func BestTarget_ObsidianFlame($a_f_AggroRange)
 	; This article is about a spell. For the guild found in Cantha, see Obsidian Flame (guild).
 	; Concise description
 	; green; font-weight: bold;">22...94...112
-	Return 0
+	; Target: Grouped enemies (AOE fire damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 220 - $GC_I_SKILL_ID_BLINDING_FLASH
@@ -1175,7 +1228,8 @@ Func BestTarget_ChainLightning($a_f_AggroRange)
 	; Spell. Target foe and up to two other foes near your target are struck for 10...70...85 lightning damage. This spell has 25% armor penetration.
 	; Concise description
 	; Spell. Deals 10...70...85 lightning damage. Also hits two foes near your target. 25% armor penetration.
-	Return 0
+	; Target: Grouped enemies (AOE chaining damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 224 - $GC_I_SKILL_ID_ENERVATING_CHARGE
@@ -1189,7 +1243,8 @@ Func BestTarget_EnervatingCharge($a_f_AggroRange)
 	; Spell. Target foe is struck for 25...45...50 lightning damage and suffers from Weakness for 5...17...20 seconds. This spell has 25% armor penetration.
 	; Concise description
 	; Spell. Deals 25...45...50 lightning damage. Inflicts Weakness condition (5...17...20 seconds). 25% armor penetration.
-	Return 0
+	; Target: Nearest enemy (condition application)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 226 - $GC_I_SKILL_ID_MIND_SHOCK
@@ -1203,7 +1258,8 @@ Func BestTarget_MindShock($a_f_AggroRange)
 	; Elite Spell. Target foe suffers 10...42...50 lightning damage. If you have more Energy than target foe, that foe suffers 10...42...50 more lightning damage and is knocked down. This spell has 25% armor penetration.
 	; Concise description
 	; Elite Spell. Deals 10...42...50 lightning damage. If you have more Energy than target foe, deals +10...42...50 lightning damage and causes knockdown. 25% armor penetration.
-	Return 0
+	; Target: Nearest enemy (elite damage/knockdown)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 228 - $GC_I_SKILL_ID_THUNDERCLAP
@@ -1217,7 +1273,8 @@ Func BestTarget_Thunderclap($a_f_AggroRange)
 	; Elite Spell. Create a massive shockwave at target foe's location. Deals 10...42...50 lightning damage to target and all adjacent foes. Struck foes are interrupted and suffer from Cracked Armor and Weakness for 5...17...20 seconds. This spell has 25% armor penetration.
 	; Concise description
 	; Elite Spell. Deals 10...42...50 lightning damage. Also strikes adjacent foes. Inflicts Cracked Armor and Weakness (5...17...20 seconds). Causes interrupt. 25% armor penetration.
-	Return 0
+	; Target: Grouped enemies (AOE interrupt + conditions)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 229 - $GC_I_SKILL_ID_LIGHTNING_ORB1
@@ -1227,7 +1284,8 @@ Func CanUse_LightningOrb1()
 EndFunc
 
 Func BestTarget_LightningOrb1($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 230 - $GC_I_SKILL_ID_LIGHTNING_JAVELIN
@@ -1258,7 +1316,8 @@ Func BestTarget_WaterTrident($a_f_AggroRange)
 	; Elite Spell. Send out a fast-moving Water Trident, striking target foe and up to 2 adjacent foes for 10...74...90 cold damage if it hits. If it hits a moving foe, that foe is knocked down.
 	; Concise description
 	; Elite Spell. Fast Projectile: deals 10...74...90 cold damage and knocks-down moving foes. Shoots 2 additional projectiles at adjacent foes.
-	Return 0
+	; Target: Lowest health enemy (projectile with knockdown)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 240 - $GC_I_SKILL_ID_SMITE
@@ -1324,7 +1383,7 @@ Func BestTarget_MendCondition($a_f_AggroRange)
 	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe|UAI_Filter_IsConditioned")
 	If $l_i_Target <> 0 Then Return $l_i_Target
 
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 276 - $GC_I_SKILL_ID_RESTORE_CONDITION
@@ -1341,7 +1400,7 @@ Func BestTarget_RestoreCondition($a_f_AggroRange)
 	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe|UAI_Filter_IsConditioned")
 	If $l_i_Target <> 0 Then Return $l_i_Target
 
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 277 - $GC_I_SKILL_ID_MEND_AILMENT
@@ -1355,7 +1414,8 @@ Func BestTarget_MendAilment($a_f_AggroRange)
 	; Spell. Remove one condition (Poison, Disease, Blindness, Dazed, Bleeding, Crippled, Burning, Weakness, Cracked Armor, or Deep Wound) from target ally. For each remaining Condition, that ally is healed for 5...57...70 Health.
 	; Concise description
 	; Spell. Removes a condition. Removal effect: heals for 5...57...70 for each remaining condition.
-	Return 0
+	; Target: Conditioned ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_IsConditioned")
 EndFunc
 
 ; Skill ID: 278 - $GC_I_SKILL_ID_PURGE_CONDITIONS
@@ -1369,7 +1429,8 @@ Func BestTarget_PurgeConditions($a_f_AggroRange)
 	; Spell. Remove all conditions (Poison, Disease, Blindness, Dazed, Bleeding, Crippled, Burning, Weakness, Cracked Armor, and Deep Wound) from target ally.
 	; Concise description
 	; Spell. Removes all conditions.
-	Return 0
+	; Target: Conditioned ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_IsConditioned")
 EndFunc
 
 ; Skill ID: 279 - $GC_I_SKILL_ID_DIVINE_HEALING
@@ -1426,12 +1487,15 @@ Func BestTarget_WordOfHealing($a_f_AggroRange)
 	; Elite Spell. Heal target ally for 5...81...100 Health. Heal for an additional 30...98...115 Health if that ally is below 50% Health.
 	; Concise description
 	; Elite Spell. Heals for 5...81...100. Heals for 30...98...115 more if target ally is below 50% Health.
-	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
-	Local $l_f_Hp = UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP)
-	If $l_i_Target <> 0 And $l_f_Hp < 0.5 Then Return $l_i_Target
-	If $l_i_Target <> 0 And ($l_f_Hp > 0.7 And $l_f_Hp < 0.9) Then Return $l_i_Target
+	; Target: Lowest health living ally
+    Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 
-	Return 0
+    ; Always return the lowest health ally if one exists. The skill's effect will handle the bonus healing based on HP.
+    If $l_i_Target <> 0 Then Return $l_i_Target
+
+    ; Final Fallback: If no other conditions are met, and no ally is below 50% HP,
+    ; just return the lowest HP ally (excluding self) if one exists.
+    Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 283 - $GC_I_SKILL_ID_DWAYNAS_KISS
@@ -1454,7 +1518,7 @@ Func BestTarget_DwaynasKiss($a_f_AggroRange)
 	$l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 	If UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.5 And $l_i_Target <> 0 Then Return $l_i_Target
 
-	Return 0
+	Return $l_i_Target
 EndFunc
 
 ; Skill ID: 286 - $GC_I_SKILL_ID_HEAL_OTHER
@@ -1468,7 +1532,8 @@ Func BestTarget_HealOther($a_f_AggroRange)
 	; Spell. Heal target other ally for 35...151...180 Health.
 	; Concise description
 	; Spell. Heals for 35...151...180. Cannot self-target.
-	Return 0
+	; Target: Lowest health ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 287 - $GC_I_SKILL_ID_HEAL_PARTY
@@ -1497,9 +1562,11 @@ Func BestTarget_InfuseHealth($a_f_AggroRange)
 	; Concise description
 	; Spell. Heals for 100...129...136% of half your current Health. Lose half your current Health. Cannot self-target.
 	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
-	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.1 Then Return $l_i_Target
+	; Priority 1: Lowest health other ally (below 10% HP)
+    If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.1 Then Return $l_i_Target
 
-	Return 0
+    ; Fallback: Any other living ally, prioritizing lowest HP
+    Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 298 - $GC_I_SKILL_ID_MARTYR
@@ -1556,7 +1623,10 @@ Func BestTarget_ConvertHexes($a_f_AggroRange)
 	; Spell. Remove all hexes from target other ally. For 8...18...20 seconds, that ally gains +10 armor for each Necromancer hex that was removed.
 	; Concise description
 	; Spell. Removes all hexes; +10 armor for each Necromancer hex removed (8...18...20 seconds). Cannot self-target.
-	Return 0
+	; Target: Hexed ally (support spell)
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 304 - $GC_I_SKILL_ID_LIGHT_OF_DWAYNA
@@ -1586,7 +1656,8 @@ Func BestTarget_Resurrect($a_f_AggroRange)
 	; This article is about the Monk skill. For the game mechanic, see Resurrection. For the monster skills, see Resurrect (monster skill) and Resurrect (Gargoyle).
 	; Concise description
 	; none" />
-	Return 0
+	; Target: Nearest dead ally (resurrection)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsDeadAlly")
 EndFunc
 
 ; Skill ID: 306 - $GC_I_SKILL_ID_REBIRTH
@@ -1601,7 +1672,8 @@ Func BestTarget_Rebirth($a_f_AggroRange)
 	; Spell. Resurrect target party member. Target party member is returned to life with 25% Health and zero Energy, and is teleported to your current location. All of target's skills are disabled for 10...4...3 seconds. This spell consumes all of your remaining Energy.
 	; Concise description
 	; Spell. Resurrects target party member (25% Health, 0 Energy). Teleports target to you. Disables target's skills (10...4...3 seconds). You lose all Energy.
-	Return 0
+	; Target: Nearest dead ally (resurrection)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsDeadAlly")
 EndFunc
 
 ; Skill ID: 311 - $GC_I_SKILL_ID_DRAW_CONDITIONS
@@ -1615,7 +1687,8 @@ Func BestTarget_DrawConditions($a_f_AggroRange)
 	; Spell. All negative conditions are transferred from target other ally to yourself. For each condition acquired, you gain 6...22...26 Health.
 	; Concise description
 	; Spell. Transfers all conditions from target ally to yourself. Transfer effect: you gain 6...22...26 Health for each condition. Cannot self-target.
-	Return 0
+	; Target: Conditioned ally (remove conditions from allies)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe|UAI_Filter_IsConditioned")
 EndFunc
 
 ; Skill ID: 313 - $GC_I_SKILL_ID_HEALING_TOUCH
@@ -1629,7 +1702,8 @@ Func BestTarget_HealingTouch($a_f_AggroRange)
 	; Spell. Heal target touched ally for 16...51...60 Health. Health gain from Divine Favor is doubled for this spell.
 	; Concise description
 	; Touch Spell. Heals for 16...51...60. Double Health gain from Divine Favor for this spell.
-	Return 0
+	; Target: Lowest health ally (touch healing)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 314 - $GC_I_SKILL_ID_RESTORE_LIFE
@@ -1644,7 +1718,8 @@ Func BestTarget_RestoreLife($a_f_AggroRange)
 	; Spell. Touch the body of a fallen party member. Target party member is returned to life with 20...56...65% Health and 42...80...90% Energy.
 	; Concise description
 	; Touch Spell. Resurrects target party member (20...56...65% Health, 42...80...90% Energy).
-	Return 0
+	; Target: Nearest dead ally (resurrection)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsDeadAlly")
 EndFunc
 
 ; Skill ID: 488 - $GC_I_SKILL_ID_ERUPTION_ENVIRONMENT
@@ -1726,7 +1801,8 @@ Func CanUse_MursaatTowerSkill()
 EndFunc
 
 Func BestTarget_MursaatTowerSkill($a_f_AggroRange)
-	Return 0
+	; Tower skill - target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 496 - $GC_I_SKILL_ID_QUICKSAND_ENVIRONMENT_EFFECT
@@ -1841,7 +1917,8 @@ Func CanUse_ResurrectGargoyle()
 EndFunc
 
 Func BestTarget_ResurrectGargoyle($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 562 - $GC_I_SKILL_ID_LIGHTNING_ORB2
@@ -1851,7 +1928,8 @@ Func CanUse_LightningOrb2()
 EndFunc
 
 Func BestTarget_LightningOrb2($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 563 - $GC_I_SKILL_ID_WURM_SIEGE_DUNES_OF_DESPAIR
@@ -1861,7 +1939,8 @@ Func CanUse_WurmSiegeDunesOfDespair()
 EndFunc
 
 Func BestTarget_WurmSiegeDunesOfDespair($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 564 - $GC_I_SKILL_ID_WURM_SIEGE
@@ -1871,7 +1950,8 @@ Func CanUse_WurmSiege()
 EndFunc
 
 Func BestTarget_WurmSiege($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 566 - $GC_I_SKILL_ID_SHIVER_TOUCH
@@ -1885,7 +1965,8 @@ Func BestTarget_ShiverTouch($a_f_AggroRange)
 	; Monster skill
 	; Concise description
 	; 1em; margin-bottom:1em; clear:both;" />
-	Return 0
+	; Target: Nearest enemy (monster skill)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 568 - $GC_I_SKILL_ID_VANISH
@@ -1913,7 +1994,10 @@ Func BestTarget_DisruptingDagger($a_f_AggroRange)
 	; Spell. Send out a Disrupting Dagger at target foe that strikes for 10...30...35 earth damage. If that foe was activating a skill, that skill is interrupted. This spell has half the normal range.
 	; Concise description
 	; Half Range Spell. Projectile: deals 10...30...35 earth damage. Interrupts a skill.
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 576 - $GC_I_SKILL_ID_STATUES_BLESSING
@@ -1923,7 +2007,8 @@ Func CanUse_StatuesBlessing()
 EndFunc
 
 Func BestTarget_StatuesBlessing($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 579 - $GC_I_SKILL_ID_DOMAIN_OF_SKILL_DAMAGE
@@ -2083,7 +2168,7 @@ Func BestTarget_GazeOfContempt($a_f_AggroRange)
 	; Spell. If target foe has more than 50% Health, that foe loses all enchantments.
 	; Concise description
 	; Spell. Removes target foe's enchantments. No effect unless this foe has more than 50% Health.
-	Return 0
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 769 - $GC_I_SKILL_ID_VIPERS_DEFENSE
@@ -2093,7 +2178,8 @@ Func CanUse_VipersDefense()
 EndFunc
 
 Func BestTarget_VipersDefense($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 770 - $GC_I_SKILL_ID_RETURN
@@ -2107,7 +2193,7 @@ Func BestTarget_Return($a_f_AggroRange)
 	; Spell. All adjacent foes are Crippled for 3...7...8 seconds. Shadow Step to target other ally's location.
 	; Concise description
 	; Spell. Inflicts Crippled condition (3...7...8 seconds) on all foes adjacent to you. You Shadow Step to target ally's location. Cannot self-target.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 784 - $GC_I_SKILL_ID_ENTANGLING_ASP
@@ -2121,7 +2207,7 @@ Func BestTarget_EntanglingAsp($a_f_AggroRange)
 	; Spell. Entangling Asp must follow a lead attack. Target foe is knocked down and becomes Poisoned for 5...17...20 seconds.
 	; Concise description
 	; Spell. Causes knock-down. Inflicts Poisoned condition (5...17...20 seconds). Must follow a lead attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 791 - $GC_I_SKILL_ID_FLESH_OF_MY_FLESH
@@ -2136,7 +2222,7 @@ Func BestTarget_FleshOfMyFlesh($a_f_AggroRange)
 	; Spell. Lose half your Health. Resurrect target party member with your current Health and 5...17...20% Energy.
 	; Concise description
 	; Spell. Resurrect target party member (half your current Health and 5...17...20% Energy). Lose half your Health.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsDeadAlly")
 EndFunc
 
 ; Skill ID: 796 - $GC_I_SKILL_ID_SORROWS_FLAME
@@ -2184,7 +2270,7 @@ Func BestTarget_BeguilingHaze($a_f_AggroRange)
 	; Elite Spell. Shadow Step to target foe. That foe becomes Dazed for 3...8...9 seconds.
 	; Concise description
 	; Elite Spell. You Shadow Step to this foe. Inflicts Dazed condition (3...8...9 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 805 - $GC_I_SKILL_ID_ANIMATE_VAMPIRIC_HORROR
@@ -2214,7 +2300,7 @@ Func BestTarget_Discord($a_f_AggroRange)
 	; Elite Spell. Deals 30...94...110 damage. No effect unless target foe has a condition and is either hexed or enchanted.
 	$l_i_Target = UAI_GetBestSingleTarget(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsHexedOrEnchanted|UAI_Filter_IsConditioned")
 	If $l_i_Target <> 0 Then Return $l_i_Target
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 824 - $GC_I_SKILL_ID_LAVA_ARROWS
@@ -2228,7 +2314,7 @@ Func BestTarget_LavaArrows($a_f_AggroRange)
 	; Spell. Lava Arrows fly toward up to 3 foes near your target and strike for 20...56...65 fire damage if they hit.
 	; Concise description
 	; Spell. Projectile: deals 20...56...65 fire damage. Bonus effect: sends projectiles at 2 other foes near your target.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 825 - $GC_I_SKILL_ID_BED_OF_COALS
@@ -2242,7 +2328,7 @@ Func BestTarget_BedOfCoals($a_f_AggroRange)
 	; Spell. Create a Bed of Coals at target foe's location. For 5 seconds, foes adjacent to target foe are struck for 5...24...29 fire damage each second. Any foe knocked down on the Bed of Coals is set on fire for 3...6...7 seconds.
 	; Concise description
 	; Spell. Deals 5...24...29 fire damage each second (5 seconds) to location of target foe. Hits foes adjacent to your target. Inflicts Burning condition (3...6...7 seconds) on knocked down foes.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 830 - $GC_I_SKILL_ID_RAY_OF_JUDGMENT
@@ -2284,7 +2370,7 @@ Func BestTarget_RideTheLightning($a_f_AggroRange)
 	; Elite Spell. You Ride the Lightning to target. All adjacent foes are Blinded for 1...4...5 second[s]. If your target is a foe, it is struck for 10...58...70 lightning damage. This spell has 25% armor penetration.
 	; Concise description
 	; Elite Spell. Deals 10...58...70 lightning damage. 25% armor penetration. Blinds all adjacent foes (1...4...5 second[s]). You instantly move to your target. May target allies.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 840 - $GC_I_SKILL_ID_POISONED_HEART
@@ -2312,7 +2398,7 @@ Func BestTarget_FetidGround($a_f_AggroRange)
 	; Spell. Target foe is struck for 15...55...65 cold damage. If that foe is knocked down, that foe becomes Poisoned for 5...17...20 seconds.
 	; Concise description
 	; Spell. Deals 15...55...65 cold damage. Inflicts Poisoned condition (5...17...20 seconds) if target foe is knocked-down.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 842 - $GC_I_SKILL_ID_ARC_LIGHTNING
@@ -2326,7 +2412,7 @@ Func BestTarget_ArcLightning($a_f_AggroRange)
 	; Spell. Target foe is struck for 5...33...40 lightning damage. If you are Overcast, two foes near your target are struck for 15...71...85 lightning damage. Damage from Arc Lightning has 25% armor penetration.
 	; Concise description
 	; Spell. Deals 5...33...40 lightning damage. Deals 15...71...85 lightning damage to two nearby foes if you are Overcast. 25% armor penetration.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 844 - $GC_I_SKILL_ID_CHURNING_EARTH
@@ -2340,7 +2426,7 @@ Func BestTarget_ChurningEarth($a_f_AggroRange)
 	; Spell. Create Churning Earth at target foe's location. For the next 5 seconds, Churning Earth strikes foes near that location for 10...34...40 earth damage each second. Any foe moving faster than normal when struck by Churning Earth is knocked down.
 	; Concise description
 	; Spell. Deals 10...34...40 earth damage each second (5 seconds). Hits foes near target's initial location. Causes knock-down to foes moving faster than normal.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 845 - $GC_I_SKILL_ID_LIQUID_FLAME
@@ -2354,7 +2440,7 @@ Func BestTarget_LiquidFlame($a_f_AggroRange)
 	; Spell. Target foe is struck for 7...91...112 fire damage. If that foe is attacking or casting a spell, nearby foes are also struck for 7...91...112 fire damage.
 	; Concise description
 	; Spell. Deals 7...91...112 fire damage. Deals 7...91...112 fire damage to nearby foes if target was attacking or casting.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 846 - $GC_I_SKILL_ID_STEAM1
@@ -2364,7 +2450,8 @@ Func CanUse_Steam1()
 EndFunc
 
 Func BestTarget_Steam1($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 855 - $GC_I_SKILL_ID_CHOMPER
@@ -2392,7 +2479,7 @@ Func BestTarget_DancingDaggers($a_f_AggroRange)
 	; Spell. Send out three Dancing Daggers at target foe, each striking for 5...29...35 earth damage if they hit. Dancing Daggers has half the normal range. This skill counts as a lead attack.
 	; Concise description
 	; Half Range Spell. Three projectiles: each deals 5...29...35 earth damage. Counts as a lead attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 862 - $GC_I_SKILL_ID_RAVENOUS_GAZE
@@ -2406,7 +2493,7 @@ Func BestTarget_RavenousGaze($a_f_AggroRange)
 	; Elite Spell. Deal 15...27...30 damage and steal 15...27...30 Health from target foe and all nearby foes.
 	; Concise description
 	; Elite Spell. Deals 15...27...30 damage and steals 15...27...30 Health from target and nearby foes.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 864 - $GC_I_SKILL_ID_OPPRESSIVE_GAZE
@@ -2420,7 +2507,7 @@ Func BestTarget_OppressiveGaze($a_f_AggroRange)
 	; Spell. Target foe and adjacent foes take 10...26...30 shadow damage. Foes already suffering from a condition are Poisoned and Weakened for 3...10...12 seconds.
 	; Concise description
 	; Spell. Deals 10...26...30 damage to target and adjacent foes. Inflicts Poison and Weakness (3...10...12 second) on foes suffering from a condition.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 865 - $GC_I_SKILL_ID_LIGHTNING_HAMMER
@@ -2434,7 +2521,7 @@ Func BestTarget_LightningHammer($a_f_AggroRange)
 	; Spell. Target foe is struck for 10...82...100 lightning damage and applies Cracked Armor for 5...17...20 seconds. Lightning Hammer has 25% armor penetration.
 	; Concise description
 	; Spell. Deals 10...82...100 lightning damage. Applies Cracked Armor (5...17...20 seconds). 25% armor penetration.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 866 - $GC_I_SKILL_ID_VAPOR_BLADE
@@ -2448,7 +2535,7 @@ Func BestTarget_VaporBlade($a_f_AggroRange)
 	; Spell. Target foe is struck for 15...111...135 cold damage. Vapor Blade deals half damage if that foe has any enchantments on them.
 	; Concise description
 	; Spell. Deals 15...111...135 cold damage. Half damage if target foe is enchanted.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 867 - $GC_I_SKILL_ID_HEALING_LIGHT
@@ -2468,7 +2555,7 @@ Func BestTarget_HealingLight($a_f_AggroRange)
 	$l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.8 Then Return $l_i_Target
 
-	Return 0
+	Return $l_i_Target
 EndFunc
 
 ; Skill ID: 877 - $GC_I_SKILL_ID_LYSSAS_BALANCE
@@ -2478,7 +2565,8 @@ Func CanUse_LyssasBalance()
 EndFunc
 
 Func BestTarget_LyssasBalance($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 884 - $GC_I_SKILL_ID_SEARING_FLAMES1
@@ -2488,7 +2576,8 @@ Func CanUse_SearingFlames1()
 EndFunc
 
 Func BestTarget_SearingFlames1($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 897 - $GC_I_SKILL_ID_OATH_OF_HEALING
@@ -2502,7 +2591,7 @@ Func BestTarget_OathOfHealing($a_f_AggroRange)
 	; Spell. (monster only) Heal your Guild Lord for 200 Health.
 	; Concise description
 	; Spell. (monster only) Heal Guild Lord for 200.
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 902 - $GC_I_SKILL_ID_BLOOD_OF_THE_AGGRESSOR
@@ -2516,7 +2605,7 @@ Func BestTarget_BloodOfTheAggressor($a_f_AggroRange)
 	; Spell. Steal up to 5...37...45 Health from target foe. If that foe was attacking, that foe suffers Weakness for 3...10...12 seconds.
 	; Concise description
 	; Spell. Steal 5...37...45 Health. Inflicts Weakness (3...10...12 seconds) if target foe was attacking.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 903 - $GC_I_SKILL_ID_ICY_PRISM
@@ -2530,7 +2619,7 @@ Func BestTarget_IcyPrism($a_f_AggroRange)
 	; Spell. Target foe is struck for 15...63...75 cold damage. If that foe has a Water Magic hex, Icy Prism deals +15...63...75 cold damage to all other nearby foes.
 	; Concise description
 	; Spell. Deals 15...63...75 cold damage. Deals +[sic]15...63...75 cold damage to other nearby foes if target has a Water Magic hex.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 910 - $GC_I_SKILL_ID_SPIRIT_RIFT
@@ -2544,7 +2633,7 @@ Func BestTarget_SpiritRift($a_f_AggroRange)
 	; This article is about the Factions skill. For the temporarily available Bonus Mission Pack skill, see Spirit Rift (Togo).
 	; Concise description
 	; green; font-weight: bold;">25...105...125
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 914 - $GC_I_SKILL_ID_CONSUME_SOUL
@@ -2558,7 +2647,7 @@ Func BestTarget_ConsumeSoul($a_f_AggroRange)
 	; Elite Spell. You steal 5...49...60 Health from target foe. All hostile summoned creatures in the area of that foe take 25...105...125 damage.
 	; Concise description
 	; Elite Spell. Steals 5...49...60 Health. Deal 25...105...125 damage to hostile summoned creatures in the area of target foe.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 915 - $GC_I_SKILL_ID_SPIRIT_LIGHT
@@ -2579,7 +2668,7 @@ Func BestTarget_SpiritLight($a_f_AggroRange)
 	$l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.75 Then Return $l_i_Target
 
-	Return 0
+	Return $l_i_Target
 EndFunc
 
 ; Skill ID: 917 - $GC_I_SKILL_ID_RUPTURE_SOUL
@@ -2593,7 +2682,7 @@ Func BestTarget_RuptureSoul($a_f_AggroRange)
 	; Spell. Target allied spirit is destroyed. All nearby enemies are struck for 50...122...140 lightning damage and become blinded for 3...10...12 seconds.
 	; Concise description
 	; Spell. Destroys target allied spirit. Deals 50...122...140 lightning damage and inflicts Blindness condition (3...10...12 seconds) to nearby foes.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsSpirit")
 EndFunc
 
 ; Skill ID: 918 - $GC_I_SKILL_ID_SPIRIT_TO_FLESH
@@ -2603,7 +2692,8 @@ Func CanUse_SpiritToFlesh()
 EndFunc
 
 Func BestTarget_SpiritToFlesh($a_f_AggroRange)
-	Return 0
+	; Target lowest health ally
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 919 - $GC_I_SKILL_ID_SPIRIT_BURN
@@ -2631,7 +2721,7 @@ Func BestTarget_PowerReturn($a_f_AggroRange)
 	; Spell. If target foe is casting a spell or chant, that skill is interrupted and target foe gains 10...6...5 Energy.
 	; Concise description
 	; Spell. Interrupts a spell or chant. Interruption effect: target foe gains 10...6...5 Energy.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 932 - $GC_I_SKILL_ID_COMPLICATE
@@ -2645,7 +2735,7 @@ Func BestTarget_Complicate($a_f_AggroRange)
 	; Spell. If target foe is using a skill, that skill is interrupted and disabled for target foe and all foes in the area for an additional 5...11...12 seconds.
 	; Concise description
 	; Spell. Interrupt a skill. Interruption effect: disables interrupted skill (+5...11...12 seconds) for target foe and all foes in the area.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 933 - $GC_I_SKILL_ID_SHATTER_STORM
@@ -2659,7 +2749,7 @@ Func BestTarget_ShatterStorm($a_f_AggroRange)
 	; Elite Spell. Target foe loses all enchantments. For each enchantment removed this way, Shatter Storm is disabled for an additional 7 seconds.
 	; Concise description
 	; Elite Spell. Removes all enchantments. Removal cost: Shatter Storm is disabled for +7 seconds for each enchantment removed.
-	Return 0
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
 EndFunc
 
 ; Skill ID: 936 - $GC_I_SKILL_ID_ENVENOM_ENCHANTMENTS
@@ -2673,7 +2763,7 @@ Func BestTarget_EnvenomEnchantments($a_f_AggroRange)
 	; Spell. Target foe loses one enchantment. For every remaining enchantment, target foe is poisoned for 3...9...10 seconds.
 	; Concise description
 	; Spell. Removes one enchantment from target foe. Inflicts Poisoned condition (3...9...10 seconds for each remaining enchantment on that foe).
-	Return 0
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
 EndFunc
 
 ; Skill ID: 937 - $GC_I_SKILL_ID_SHOCKWAVE
@@ -2727,7 +2817,7 @@ Func BestTarget_BlessedLight($a_f_AggroRange)
 	$l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.7 Then Return $l_i_Target
 
-	Return 0
+	Return $l_i_Target
 EndFunc
 
 ; Skill ID: 942 - $GC_I_SKILL_ID_WITHDRAW_HEXES
@@ -2741,7 +2831,7 @@ Func BestTarget_WithdrawHexes($a_f_AggroRange)
 	; Elite Spell. Remove all hexes from target ally and all adjacent allies. This spell takes an additional 20...8...5 seconds to recharge for each hex removed in this way.
 	; Concise description
 	; Elite Spell. Removes all hexes. Also affects adjacent allies. Removal cost: +20...8...5 seconds recharge for each hex removed.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsHexed")
 EndFunc
 
 ; Skill ID: 943 - $GC_I_SKILL_ID_EXTINGUISH
@@ -2783,7 +2873,7 @@ Func BestTarget_ExpelHexes($a_f_AggroRange)
 	; Elite Spell. Remove up to 2 Hexes from target ally.
 	; Concise description
 	; Elite Spell. Removes 2 hexes from target ally.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsHexed")
 EndFunc
 
 ; Skill ID: 955 - $GC_I_SKILL_ID_RIP_ENCHANTMENT
@@ -2797,7 +2887,7 @@ Func BestTarget_RipEnchantment($a_f_AggroRange)
 	; Spell. Remove 1 enchantment from target foe. If an enchantment was removed, that foe suffers from Bleeding for 5...21...25 seconds.
 	; Concise description
 	; Spell. Removes 1 enchantment. Removal effect: inflicts Bleeding (5...21...25 seconds).
-	Return 0
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
 EndFunc
 
 ; Skill ID: 958 - $GC_I_SKILL_ID_HEALING_WHISPER
@@ -2811,7 +2901,7 @@ Func BestTarget_HealingWhisper($a_f_AggroRange)
 	; Spell. Target other ally is healed for 40...88...100. This spell has half the normal range.
 	; Concise description
 	; Half Range Spell. Heals for 40...88...100. Cannot self-target.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 959 - $GC_I_SKILL_ID_ETHEREAL_LIGHT
@@ -2825,7 +2915,7 @@ Func BestTarget_EtherealLight($a_f_AggroRange)
 	; Spell. Target ally is healed for 25...85...100. This spell is easily interrupted.
 	; Concise description
 	; Spell. Heals for 25...85...100. Easily interrupted.
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 960 - $GC_I_SKILL_ID_RELEASE_ENCHANTMENTS
@@ -2859,7 +2949,7 @@ Func BestTarget_SpiritTransfer($a_f_AggroRange)
 	$l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.5 Then Return $l_i_Target
 
-	Return 0
+	Return $l_i_Target
 EndFunc
 
 ; Skill ID: 965 - $GC_I_SKILL_ID_ARCHEMORUS_STRIKE
@@ -2929,7 +3019,8 @@ Func CanUse_ArgosCry()
 EndFunc
 
 Func BestTarget_ArgosCry($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 972 - $GC_I_SKILL_ID_JADE_FURY
@@ -2957,7 +3048,7 @@ Func BestTarget_BlindingPowder($a_f_AggroRange)
 	; Spell. Must follow an off-hand attack. Target foe and all adjacent foes become Blinded for 3...13...15 seconds.
 	; Concise description
 	; Spell. Inflicts Blindness condition (3...13...15 seconds) on target and adjacent foes. Must follow an off-hand attack.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 974 - $GC_I_SKILL_ID_MANTIS_TOUCH
@@ -2971,7 +3062,7 @@ Func BestTarget_MantisTouch($a_f_AggroRange)
 	; Spell. Must follow a lead attack. Target foe becomes Crippled for 5...17...20 seconds. This skill counts as an off-hand attack.
 	; Concise description
 	; Spell. Inflicts Crippled condition (5...17...20 seconds). This skill counts as an off-hand attack. Must follow a lead attack.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 980 - $GC_I_SKILL_ID_FEAST_OF_SOULS
@@ -2999,7 +3090,7 @@ Func BestTarget_Caltrops($a_f_AggroRange)
 	; Spell. Target foe and all foes adjacent to your target are Crippled for 5...13...15 seconds. Caltrops has half the normal range.
 	; Concise description
 	; Half Range Spell. Inflicts Crippled condition (5...13...15 seconds) on target and adjacent foes.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 991 - $GC_I_SKILL_ID_DENY_HEXES
@@ -3013,7 +3104,7 @@ Func BestTarget_DenyHexes($a_f_AggroRange)
 	; Spell. Remove one hex from target ally and one additional hex for each recharging Divine Favor skill you have.
 	; Concise description
 	; Spell. Removes one hex from target ally and one additional hex for each recharging Divine Favor skill you have.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsHexed")
 EndFunc
 
 ; Skill ID: 1000 - $GC_I_SKILL_ID_BLINDING_SNOW
@@ -3027,7 +3118,7 @@ Func BestTarget_BlindingSnow($a_f_AggroRange)
 	; Spell. You interrupt target foe's action. That foe is Blinded for 10 seconds.
 	; Concise description
 	; Spell. Interrupts an action. Also inflicts Blindness (10 seconds.)
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1001 - $GC_I_SKILL_ID_AVALANCHE_SKILL
@@ -3037,7 +3128,8 @@ Func CanUse_AvalancheSkill()
 EndFunc
 
 Func BestTarget_AvalancheSkill($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1002 - $GC_I_SKILL_ID_SNOWBALL
@@ -3051,7 +3143,7 @@ Func BestTarget_Snowball($a_f_AggroRange)
 	; This article is about the skill used by player characters. For the skill used by Kimberly, see Snowball (NPC).
 	; Concise description
 	; deals 50 damage. You gain 1 strike of adrenaline.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1003 - $GC_I_SKILL_ID_MEGA_SNOWBALL
@@ -3065,7 +3157,7 @@ Func BestTarget_MegaSnowball($a_f_AggroRange)
 	; Spell. You throw a very slow-moving snowball at target foe. That foe is knocked down and takes 75 damage if it hits.
 	; Concise description
 	; Spell. Very slow projectile: deals 75 damage and causes knock-down.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1011 - $GC_I_SKILL_ID_HOLIDAY_BLUES
@@ -3093,7 +3185,7 @@ Func BestTarget_FlurryOfIce($a_f_AggroRange)
 	; Spell. Throw a snowball at up to 4 foes adjacent to your target. These snowballs deal 50 damage if they hit.
 	; Concise description
 	; Spell. Throw a snowball at up to 4 foes adjacent to your target. These snowballs deal 50 damage if they hit.
-	Return 0
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1016 - $GC_I_SKILL_ID_SNOWBALL_NPC
@@ -3103,7 +3195,8 @@ Func CanUse_SnowballNpc()
 EndFunc
 
 Func BestTarget_SnowballNpc($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1032 - $GC_I_SKILL_ID_HEART_OF_SHADOW
@@ -3117,7 +3210,7 @@ Func BestTarget_HeartOfShadow($a_f_AggroRange)
 	; Spell. You are healed for 30...126...150. Shadow Step to a nearby location directly away from your target.
 	; Concise description
 	; Spell. You are healed for 30...126...150 and you Shadow Step to a nearby location directly away from your target.
-	Return 0
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1038 - $GC_I_SKILL_ID_CRIPPLING_DAGGER
@@ -3131,7 +3224,7 @@ Func BestTarget_CripplingDagger($a_f_AggroRange)
 	; Spell. Send out a Crippling Dagger at target foe. Crippling Dagger strikes for 15...51...60 earth damage if it hits, and Cripples moving foes for 3...13...15 seconds. This spell has half the normal range.
 	; Concise description
 	; Half Range Spell. Projectile: deals 15...51...60 earth damage. Inflicts Crippled condition (3...13...15 seconds) if target foe is moving.
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1040 - $GC_I_SKILL_ID_SPIRIT_WALK
@@ -3145,7 +3238,7 @@ Func BestTarget_SpiritWalk($a_f_AggroRange)
 	; Spell. Shadow Step to target spirit.
 	; Concise description
 	; Spell. Shadow Step to target Spirit. [sic]
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsSpirit")
 EndFunc
 
 ; Skill ID: 1048 - $GC_I_SKILL_ID_REVEALED_ENCHANTMENT
@@ -3173,7 +3266,7 @@ Func BestTarget_RevealedHex($a_f_AggroRange)
 	; Spell. Remove a hex from target ally and gain 4...9...10 Energy. For 20 seconds, Revealed Hex is replaced with the hex that was removed.
 	; Concise description
 	; Spell. Removes a hex from target ally. Removal effects: you gain 4...9...10 Energy; this spell is replaced with that hex (20 seconds).
-	Return 0
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsHexed")
 EndFunc
 
 ; Skill ID: 1052 - $GC_I_SKILL_ID_ACCUMULATED_PAIN
@@ -3187,7 +3280,13 @@ Func BestTarget_AccumulatedPain($a_f_AggroRange)
 	; Spell. Target foe takes 15...63...75 damage. If target foe is suffering from 2 or more hexes, that foe suffers a Deep Wound for 5...17...20 seconds.
 	; Concise description
 	; Spell. Deals 15...63...75 damage. Inflicts Deep Wound condition (5...17...20 seconds) if target foe has 2 or more hexes.
-	Return 0
+	; Target: Enemy with 2+ hexes (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then
+		Local $l_i_HexCount = UAI_CountAgents($l_i_Target, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsHex")
+		If $l_i_HexCount >= 2 Then Return $l_i_Target
+	EndIf
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1053 - $GC_I_SKILL_ID_PSYCHIC_DISTRACTION
@@ -3201,7 +3300,8 @@ Func BestTarget_PsychicDistraction($a_f_AggroRange)
 	; Elite Spell. All of your other skills are disabled for 8 seconds. If target foe is using a skill, that skill is interrupted and disabled for an additional 5...11...12 seconds.
 	; Concise description
 	; Elite Spell. Interrupts a skill. Interruption effect: disables interrupted skill (+5...11...12 seconds). Your other skills are disabled (8 seconds).
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 1057 - $GC_I_SKILL_ID_PSYCHIC_INSTABILITY
@@ -3215,7 +3315,8 @@ Func BestTarget_PsychicInstability($a_f_AggroRange)
 	; Elite Spell. Interrupt the target foe's action. If that action was a skill, that foe and nearby foes are knocked down for 2...4...4 seconds. (50% failure chance with Fast Casting 4 or less.)
 	; Concise description
 	; Elite Spell. Interrupts an action. Interruption effect: if the action is a skill, cause knockdown for 2...4...4 seconds on target foe and all nearby foes. 50% failure chance unless Fast Casting 5 or higher.
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 1060 - $GC_I_SKILL_ID_CELESTIAL_HASTE
@@ -3243,7 +3344,8 @@ Func BestTarget_Feedback($a_f_AggroRange)
 	; This article is about the skill. For the Feedback namespace main page, see Feedback:Main.
 	; Concise description
 	; target foe loses
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 1062 - $GC_I_SKILL_ID_ARCANE_LARCENY
@@ -3257,7 +3359,10 @@ Func BestTarget_ArcaneLarceny($a_f_AggroRange)
 	; Spell. For 5...29...35 seconds, one random spell is disabled for target foe and Arcane Larceny is replaced by that spell.
 	; Concise description
 	; Spell. (5...29...35 seconds.) Disables one random spell. This skill becomes that spell.
-	Return 0
+	; Target: Caster enemy (highest priority)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1067 - $GC_I_SKILL_ID_LIFEBANE_STRIKE
@@ -3271,7 +3376,8 @@ Func BestTarget_LifebaneStrike($a_f_AggroRange)
 	; Spell. Target foe takes 12...41...48 shadow damage. If that foe's Health is above 50%, you steal up to 12...41...48 Health.
 	; Concise description
 	; Spell. Deals 12...41...48 damage. Steals 12...41...48 Health if target foe's Health is above 50%.
-	Return 0
+	; Target: Highest health enemy (life steal bonus)
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1068 - $GC_I_SKILL_ID_BITTER_CHILL
@@ -3285,7 +3391,8 @@ Func BestTarget_BitterChill($a_f_AggroRange)
 	; Spell. Target foe is struck for 15...51...60 cold damage. If that foe had more Health than you, Bitter Chill recharges instantly.
 	; Concise description
 	; Spell. Deals 15...51...60 cold damage. Recharges instantly if target foe had more Health than you.
-	Return 0
+	; Target: Highest health enemy (bonus damage/recharge)
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1069 - $GC_I_SKILL_ID_TASTE_OF_PAIN
@@ -3299,7 +3406,8 @@ Func BestTarget_TasteOfPain($a_f_AggroRange)
 	; Spell. If target foe is below 50% Health, you gain 30...126...150 Health.
 	; Concise description
 	; Spell. Heals you for 30...126...150. No effect unless target foe is below 50% Health.
-	Return 0
+	; Target: Lowest health enemy (healing requirement)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1070 - $GC_I_SKILL_ID_DEFILE_ENCHANTMENTS
@@ -3313,7 +3421,10 @@ Func BestTarget_DefileEnchantments($a_f_AggroRange)
 	; Spell. Target foe and all nearby foes take 6...49...60 shadow damage and 4...17...20 shadow damage for each enchantment on them.
 	; Concise description
 	; Spell. Deals 6...49...60 damage to target and nearby foes. Deals 4...17...20 more damage for each enchantment on them.
-	Return 0
+	; Target: Grouped enchanted enemies (AOE damage)
+	Local $l_i_Target = UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1075 - $GC_I_SKILL_ID_VAMPIRIC_SWARM
@@ -3327,7 +3438,8 @@ Func BestTarget_VampiricSwarm($a_f_AggroRange)
 	; Spell. Vampiric Swarm steals up to 15...51...60 Health from up to three foes in the area.
 	; Concise description
 	; Spell. Steals 15...51...60 Health. Hits 2 additional foes in the area.
-	Return 0
+	; Target: Grouped enemies (AOE life steal)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1076 - $GC_I_SKILL_ID_BLOOD_DRINKER
@@ -3341,7 +3453,8 @@ Func BestTarget_BloodDrinker($a_f_AggroRange)
 	; This article is about the skill. For the creature, see Blood Drinker (NPC).
 	; Concise description
 	; green; font-weight: bold;">20...56...65
-	Return 0
+	; Target: Grouped enemies (AOE life steal)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1081 - $GC_I_SKILL_ID_TEINAIS_WIND
@@ -3351,7 +3464,8 @@ Func CanUse_TeinaisWind()
 EndFunc
 
 Func BestTarget_TeinaisWind($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1082 - $GC_I_SKILL_ID_SHOCK_ARROW
@@ -3365,7 +3479,10 @@ Func BestTarget_ShockArrow($a_f_AggroRange)
 	; Spell. Send out a shocking arrow that flies swiftly toward target foe, striking for 5...41...50 lightning damage. If Shock Arrow strikes a foe suffering from Cracked Armor, you gain 5 Energy plus 1 Energy for every 2 ranks of Energy Storage. Shock Arrow has 25% armor penetration.
 	; Concise description
 	; Spell. Rapid projectile: deals 5...41...50 lightning damage. Gain 5 Energy plus 1 Energy for every 2 ranks of Energy Storage if you hit a foe suffering from Cracked Armor. 25% armor penetration.
-	Return 0
+	; Target: Enemy with Cracked Armor (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1083 - $GC_I_SKILL_ID_UNSTEADY_GROUND
@@ -3379,7 +3496,8 @@ Func BestTarget_UnsteadyGround($a_f_AggroRange)
 	; Elite Spell. You create Unsteady Ground at target foe's location. For 5 seconds, nearby foes take 10...34...40 earth damage each second. Attacking foes struck by Unsteady Ground are knocked down.
 	; Concise description
 	; Elite Spell. Deals 10...34...40 earth damage each second (5 seconds) and causes knock-down to attacking foes. Hits foes near target's initial location.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1086 - $GC_I_SKILL_ID_DRAGONS_STOMP
@@ -3389,7 +3507,8 @@ Func CanUse_DragonsStomp()
 EndFunc
 
 Func BestTarget_DragonsStomp($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1088 - $GC_I_SKILL_ID_SECOND_WIND
@@ -3431,7 +3550,8 @@ Func BestTarget_StarBurst($a_f_AggroRange)
 	; Elite Spell. Target touched foe and all foes in the area are struck for 7...91...112 fire damage and set on fire for 1...3...4 second[s]. For each foe you hit, gain 2 Energy.
 	; Concise description
 	; Elite Touch Spell. Deals 7...91...112 fire damage. Inflicts Burning (1...3...4 seconds). [sic] Gain 2 Energy for each foe struck. Also hits foes in the area.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1099 - $GC_I_SKILL_ID_TEINAIS_CRYSTALS
@@ -3441,7 +3561,8 @@ Func CanUse_TeinaisCrystals()
 EndFunc
 
 Func BestTarget_TeinaisCrystals($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1106 - $GC_I_SKILL_ID_SHIELD_OF_SAINT_VIKTOR
@@ -3543,10 +3664,8 @@ Func BestTarget_HealingBurst($a_f_AggroRange)
 	; Elite Spell. Target ally is healed for 10...130...160. All party members in earshot of your target gain Health equal to the Divine Favor bonus from this spell. Your Smiting Prayers are disabled for 20 seconds.
 	; Concise description
 	; Elite Spell. Heals for 10...130...160. Party members in earshot of your target gain Health equal to the Divine Favor bonus. Disables your Smiting Prayers (20 seconds).
-	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
-	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.75 Then Return $l_i_Target
-
-	Return 0
+	; Target: Lowest health ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 1119 - $GC_I_SKILL_ID_KAREIS_HEALING_CIRCLE
@@ -3566,7 +3685,8 @@ Func CanUse_JameisGaze()
 EndFunc
 
 Func BestTarget_JameisGaze($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1121 - $GC_I_SKILL_ID_GIFT_OF_HEALTH
@@ -3580,10 +3700,8 @@ Func BestTarget_GiftOfHealth($a_f_AggroRange)
 	; Spell. All of your other Healing Prayers skills are disabled for 10...6...5 seconds. Target other ally is healed for 15...123...150 Health.
 	; Concise description
 	; Spell. Heals for 15...123...150. Disables your other Healing Prayers skills (10...6...5 seconds). Cannot self-target.
-	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
-	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.75 Then Return $l_i_Target
-
-	Return 0
+	; Target: Lowest health ally (support spell, cannot self-target)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 1126 - $GC_I_SKILL_ID_EMPATHIC_REMOVAL
@@ -3597,7 +3715,11 @@ Func BestTarget_EmpathicRemoval($a_f_AggroRange)
 	; Elite Spell. You and target other ally lose 1 condition and 1 hex, and are healed for 50.
 	; Concise description
 	; Elite Spell. Removes one condition and hex from target ally and yourself, and heals for 50. Cannot self-target.
-	Return 0
+	; Target: Conditioned ally (highest priority), fallback to lowest health ally
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsConditioned|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 1128 - $GC_I_SKILL_ID_RESURRECTION_CHANT
@@ -3612,6 +3734,8 @@ Func BestTarget_ResurrectionChant($a_f_AggroRange)
 	; Spell. Resurrect target party member with up to your current Health and 5...29...35% Energy. This spell has half the normal range.
 	; Concise description
 	; Half Range Spell. Resurrects target party member at your current Health and with 5...29...35% Energy.
+	; Target: Dead ally (resurrection priority)
+	; Note: This would need a dead ally filter to work properly
 	Return 0
 EndFunc
 
@@ -3626,7 +3750,8 @@ Func BestTarget_WordOfCensure($a_f_AggroRange)
 	; Elite Spell. Target foe takes 15...63...75 holy damage. If your target was below 33% Health, Word of Censure takes 20 additional seconds to recharge.
 	; Concise description
 	; Elite Spell. Deals 15...63...75 holy damage. +20 recharge time if target foe is below 33% Health.
-	Return 0
+	; Target: Lowest health enemy (bonus recharge)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1130 - $GC_I_SKILL_ID_SPEAR_OF_LIGHT
@@ -3640,7 +3765,10 @@ Func BestTarget_SpearOfLight($a_f_AggroRange)
 	; Spell. Spear of Light flies toward target foe and deals 26...50...56 holy damage if it hits. Spear of Light deals +15...51...60 damage if it hits an attacking foe.
 	; Concise description
 	; Spell. Projectile: deals 26...50...56 holy damage. Deals 15...51...60 more damage if target foe is attacking.
-	Return 0
+	; Target: Attacking enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsAttacking")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1174 - $GC_I_SKILL_ID_CATHEDRAL_COLLAPSE2
@@ -3678,7 +3806,10 @@ Func BestTarget_CorruptedDragonSpores($a_f_AggroRange)
 	; Spell. Create 6 "Corrupted Spore" creatures around target foe. Foes within their range take 100% longer to cast spells and suffer from -2 Health degeneration. Corrupted Spore creatures die after 30 seconds.
 	; Concise description
 	; Spell. (30 seconds.) Create 6 corrupted spore creatures around target foe. Foes within their range take twice as long to cast spells and have -2 Health degeneration.
-	Return 0
+	; Target: Grouped casters (debuff priority)
+	Local $l_i_Target = UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1184 - $GC_I_SKILL_ID_CORRUPTED_DRAGON_SCALES
@@ -3692,7 +3823,8 @@ Func BestTarget_CorruptedDragonScales($a_f_AggroRange)
 	; Spell. Create 6 "Corrupted Scale" creatures around target foe. Foes within their range attack 50% slower and suffer from -10 Health degeneration. Corrupted Scale creatures die after 30 seconds.
 	; Concise description
 	; Spell. (30 seconds.) Create 6 corrupted scale creatures around target foe. Foes within their range attack 50% slower and have -10 Health degeneration.
-	Return 0
+	; Target: Grouped enemies (AOE debuff)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1189 - $GC_I_SKILL_ID_OF_ROYAL_BLOOD
@@ -3730,7 +3862,8 @@ Func BestTarget_ClamorOfSouls($a_f_AggroRange)
 	; Elite Spell. Target foe and all nearby foes take 10...54...65 lightning damage. If you are within earshot of a spirit or holding a bundle item, you gain 10 Energy.
 	; Concise description
 	; Elite Spell. Deals 10...54...65 lightning damage to target and nearby foes. You gain 10 Energy if you are within earshot of a spirit or holding a bundle item.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1216 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -3745,7 +3878,8 @@ Func BestTarget_DrawSpirit($a_f_AggroRange)
 	; Spell. Teleport target allied spirit to your location.
 	; Concise description
 	; Spell. Teleports target allied spirit to your location.
-	Return 0
+	; Target: Self (teleports spirit to player)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1225 - $GC_I_SKILL_ID_CHANNELED_STRIKE
@@ -3759,7 +3893,8 @@ Func BestTarget_ChanneledStrike($a_f_AggroRange)
 	; Spell. Target foe is struck for 5...77...95 lightning damage. That foe is struck for an additional 5...29...35 lightning damage if you are holding an item.
 	; Concise description
 	; Spell. Deals 5...77...95 lightning damage. Deals 5...29...35 additional lightning damage if you are holding an item.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1226 - $GC_I_SKILL_ID_SPIRIT_BOON_STRIKE
@@ -3773,7 +3908,8 @@ Func BestTarget_SpiritBoonStrike($a_f_AggroRange)
 	; Spell. Target foe is struck for 20...56...65 lightning damage, and all spirits you control within earshot gain 20...56...65 Health.
 	; Concise description
 	; Spell. Deals 20...56...65 lightning damage. Spirits you control within earshot gain 20...56...65 Health.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1227 - $GC_I_SKILL_ID_ESSENCE_STRIKE
@@ -3816,7 +3952,8 @@ Func BestTarget_SoothingMemories($a_f_AggroRange)
 	; Spell. Target ally is healed for 10...82...100 Health. If you are holding an item, you gain 3 Energy.
 	; Concise description
 	; Spell. Heals for 10...82...100. You gain 3 Energy if you are holding an item.
-	Return 0
+	; Target: Lowest health ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 1234 - $GC_I_SKILL_ID_MEND_BODY_AND_SOUL
@@ -3834,10 +3971,7 @@ Func BestTarget_MendBodyAndSoul($a_f_AggroRange)
 	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_IsConditioned")
 	If $l_i_Target <> 0 And $l_i_SpiritCount >= 1 Then Return $l_i_Target
 
-	$l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
-	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.75 Then Return $l_i_Target
-
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 1242 - $GC_I_SKILL_ID_ARCHEMORUS_STRIKE_CELESTIAL_SUMMONING
@@ -3867,7 +4001,8 @@ Func CanUse_GazeFromBeyond()
 EndFunc
 
 Func BestTarget_GazeFromBeyond($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1262 - $GC_I_SKILL_ID_HEALING_RING
@@ -3896,6 +4031,7 @@ Func BestTarget_RenewLife($a_f_AggroRange)
 	; Spell. Resurrect target touched dead target  party member with 50% Health and 5...17...20% Energy. That party member and all allies within earshot are healed for 55...115...130 Health.
 	; Concise description
 	; Touch Spell. Resurrects target party member (50% Health and 5...17...20% Energy). Heals allies within earshot for 55...115...130.
+	; Target: Dead ally (resurrection priority)
 	Return 0
 EndFunc
 
@@ -3910,7 +4046,8 @@ Func BestTarget_Doom($a_f_AggroRange)
 	; Spell. Strike target foe for 10...34...40 lightning (maximum 135) damage for every recharging binding ritual you have.
 	; Concise description
 	; Spell. Deals 10...34...40 lightning damage (maximum 135) for each of your recharging binding rituals.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1265 - $GC_I_SKILL_ID_WIELDERS_BOON
@@ -3920,7 +4057,8 @@ Func CanUse_WieldersBoon()
 EndFunc
 
 Func BestTarget_WieldersBoon($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1277 - $GC_I_SKILL_ID_BATTLE_CRY2
@@ -4036,7 +4174,10 @@ Func BestTarget_ExtendConditions($a_f_AggroRange)
 	; Elite Spell. Spread all conditions from target foe to foes near your target. The durations of those conditions are increased by 5...81...100% (maximum 30 seconds).
 	; Concise description
 	; Elite Spell. Spread all conditions from target foe to foes near your target. Those [sic] durations of those conditions are increased by 5...81...100% (maximum 30 seconds).
-	Return 0
+	; Target: Conditioned enemy with grouped enemies nearby
+	Local $l_i_Target = UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1334 - $GC_I_SKILL_ID_HYPOCHONDRIA
@@ -4050,7 +4191,8 @@ Func BestTarget_Hypochondria($a_f_AggroRange)
 	; Spell. Transfer all conditions from all foes in the area to target foe.
 	; Concise description
 	; Spell. Transfer all conditions from foes in the area to target foe.
-	Return 0
+	; Target: Grouped enemies (condition transfer)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1336 - $GC_I_SKILL_ID_SPIRITUAL_PAIN
@@ -4108,7 +4250,10 @@ Func BestTarget_DrainDelusions($a_f_AggroRange)
 	; Spell. Remove one Mesmer hex from target foe. If a hex was removed in this way, that foe loses 1...4...5 Energy and you gain 4 Energy for each point lost.
 	; Concise description
 	; Spell. Removes one Mesmer hex from target foe. Causes 1...4...5 Energy loss. You gain 4 Energy for each point lost. No effect unless a hex was removed.
-	Return 0
+	; Target: Hexed enemy (highest priority)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1342 - $GC_I_SKILL_ID_TEASE
@@ -4122,7 +4267,8 @@ Func BestTarget_Tease($a_f_AggroRange)
 	; Elite Spell. If target foe is using a skill, that foe and other foes in the area are interrupted and you steal 0...4...5 Energy from all foes in the area.
 	; Concise description
 	; Elite Spell. Interrupts a skill. Interruption effect: also interrupts other foes in the area, and you steal 0...4...5 Energy from all foes in the area.
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 1347 - $GC_I_SKILL_ID_DISCHARGE_ENCHANTMENT
@@ -4136,7 +4282,10 @@ Func BestTarget_DischargeEnchantment($a_f_AggroRange)
 	; Spell. Remove one enchantment from target foe. If that foe is hexed, this skill recharges 20...44...50% faster.
 	; Concise description
 	; Spell. Removes one enchantment from target foe. 20...44...50% faster recharge if that foe was hexed.
-	Return 0
+	; Target: Enchanted enemy (highest priority)
+	Local $l_i_Target = UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1348 - $GC_I_SKILL_ID_HEX_EATER_VORTEX
@@ -4150,7 +4299,8 @@ Func BestTarget_HexEaterVortex($a_f_AggroRange)
 	; Elite Spell. Remove a hex from target ally. If a hex is removed in this way, foes near that ally take 30...78...90 damage and lose one enchantment.
 	; Concise description
 	; Elite Spell. Removes one hex from target ally. Removal effect: deals 30...78...90 damage and removes one enchantment from foes near this ally.
-	Return 0
+	; Target: Hexed ally (support spell)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsHexed")
 EndFunc
 
 ; Skill ID: 1349 - $GC_I_SKILL_ID_MIRROR_OF_DISENCHANTMENT
@@ -4164,7 +4314,10 @@ Func BestTarget_MirrorOfDisenchantment($a_f_AggroRange)
 	; Spell. Remove one enchantment from target foe. All of that foe's party members also lose that same enchantment.
 	; Concise description
 	; Spell. Removes one enchantment from target foe. That foe's party members also lose this enchantment.
-	Return 0
+	; Target: Enchanted enemy (highest priority)
+	Local $l_i_Target = UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1350 - $GC_I_SKILL_ID_SIMPLE_THIEVERY
@@ -4178,7 +4331,8 @@ Func BestTarget_SimpleThievery($a_f_AggroRange)
 	; Elite Spell. Interrupt target foe's action. If that action was a skill, that skill is disabled for 5...17...20 seconds, and Simple Thievery is replaced by that skill.
 	; Concise description
 	; Elite Spell. Interrupts an action. Interruption effect: If a skill was interrupted, that skill is disabled and Simple Thievery becomes that skill (5...17...20 seconds).
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 1351 - $GC_I_SKILL_ID_ANIMATE_SHAMBLING_HORROR
@@ -4220,7 +4374,8 @@ Func BestTarget_PutridFlesh($a_f_AggroRange)
 	; Spell. Destroy one of your target animated undead minions. All foes near that creature are Diseased for 5...13...15 seconds.
 	; Concise description
 	; Spell. Destroys one of your undead servants. Inflicts Diseased condition (5...13...15 seconds) to foes near this servant.
-	Return 0
+	; Target: Grouped enemies (AOE condition)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1354 - $GC_I_SKILL_ID_FEAST_FOR_THE_DEAD
@@ -4230,7 +4385,8 @@ Func CanUse_FeastForTheDead()
 EndFunc
 
 Func BestTarget_FeastForTheDead($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1359 - $GC_I_SKILL_ID_PAIN_OF_DISENCHANTMENT
@@ -4244,7 +4400,10 @@ Func BestTarget_PainOfDisenchantment($a_f_AggroRange)
 	; Elite Spell. Target foe loses 1...3...3 enchantment[s]. If an enchantment was lost in this way, that foe and all adjacent foes lose 10...82...100 Health.
 	; Concise description
 	; Elite Spell. Target foe loses 1...3...3 enchantment[s]. Removal effect: that foe and all adjacent foes lose 10...82...100 Health.
-	Return 0
+	; Target: Grouped enchanted enemies (AOE damage)
+	Local $l_i_Target = UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1367 - $GC_I_SKILL_ID_BLINDING_SURGE
@@ -4258,7 +4417,8 @@ Func BestTarget_BlindingSurge($a_f_AggroRange)
 	; Elite Spell. Target foe is struck for 5...41...50 lightning damage. That foe and all adjacent foes are Blinded for 3...7...8 seconds. This spell has 25% armor penetration. If this spell strikes an attacking foe, all adjacent foes are also struck and this spell deals 50% more damage.
 	; Concise description
 	; Elite Spell. Deals 5...41...50 lightning damage. Inflicts Blindness condition (3...7...8 seconds) on target and adjacent foes. 25% armor penetration. If target was attacking, also hits adjacent foes and deals 50% more damage.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1369 - $GC_I_SKILL_ID_LIGHTNING_BOLT
@@ -4272,7 +4432,8 @@ Func BestTarget_LightningBolt($a_f_AggroRange)
 	; Spell. Send out a Lightning Bolt that strikes for 5...41...50 lightning damage if it hits. If Lightning Bolt strikes a moving foe, that foe is struck for 5...41...50 additional lightning damage. This spell has 25% armor penetration.
 	; Concise description
 	; Spell. Projectile: deals 5...41...50 lightning damage. Deals 5...41...50 more lightning damage if target foe is moving. 25% armor penetration.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1372 - $GC_I_SKILL_ID_SANDSTORM
@@ -4286,7 +4447,8 @@ Func BestTarget_Sandstorm($a_f_AggroRange)
 	; Elite Spell. Create a Sandstorm at target foe's location. For 10 seconds, nearby foes are struck for 10...26...30 earth damage each second and attacking foes are struck for an additional 10...26...30 earth damage each second.
 	; Concise description
 	; Elite Spell. Deals 10...26...30 earth damage each second (10 seconds). Hits foes near target foe's initial location. Hits attacking foes for 10...26...30 more earth damage each second.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1374 - $GC_I_SKILL_ID_EBON_HAWK
@@ -4300,7 +4462,8 @@ Func BestTarget_EbonHawk($a_f_AggroRange)
 	; Spell. Send a projectile that strikes target foe for 10...70...85 earth damage and causes Weakness for 5...13...15 seconds if it hits.
 	; Concise description
 	; Spell. Projectile: deals 10...70...85 earth damage and inflicts Weakness condition (5...13...15 seconds).
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1379 - $GC_I_SKILL_ID_GLOWING_GAZE1
@@ -4310,7 +4473,8 @@ Func CanUse_GlowingGaze1()
 EndFunc
 
 Func BestTarget_GlowingGaze1($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1380 - $GC_I_SKILL_ID_SAVANNAH_HEAT
@@ -4338,7 +4502,11 @@ Func BestTarget_WordsOfComfort($a_f_AggroRange)
 	; Spell. Target ally is healed for 15...51...60 Health and an additional 15...39...45 Health if that ally is suffering from a condition.
 	; Concise description
 	; Spell. Heals for 15...51...60. Heals for 15...39...45 more if target ally has a condition.
-	Return 0
+	; Target: Conditioned ally (highest priority), fallback to lowest health ally
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 1397 - $GC_I_SKILL_ID_LIGHT_OF_DELIVERANCE
@@ -4366,7 +4534,10 @@ Func BestTarget_MendingTouch($a_f_AggroRange)
 	; Spell. Touched ally loses two conditions and is healed for 15...51...60 Health for each condition removed in this way.
 	; Concise description
 	; Touch Spell. Removes two conditions. Heals for 15...51...60 for each condition removed.
-	Return 0
+	; Target: Conditioned ally (support spell)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly")
 EndFunc
 
 ; Skill ID: 1424 - $GC_I_SKILL_ID_STOP_PUMP
@@ -4408,7 +4579,8 @@ Func BestTarget_CorruptedHealing($a_f_AggroRange)
 	; Spell. Heal one corrupted root for 300 Health. Caster is also fully healed.
 	; Concise description
 	; Spell. Heal one corrupted root for 300. Caster is also fully healed.
-	Return 0
+	; Target: Self (heals corrupted root)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1444 - $GC_I_SKILL_ID_SUMMON_TORMENT
@@ -4492,7 +4664,8 @@ Func BestTarget_ImbueHealth($a_f_AggroRange)
 	; Spell. Target other ally is healed for 5...41...50% of your current Health (maximum 300 Health).
 	; Concise description
 	; Spell. Heals for 5...41...50% of your current Health (maximum 300). Cannot self-target.
-	Return 0
+	; Target: Lowest health ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 1527 - $GC_I_SKILL_ID_MYSTIC_HEALING
@@ -4516,7 +4689,8 @@ Func CanUse_DwaynasTouch()
 EndFunc
 
 Func BestTarget_DwaynasTouch($a_f_AggroRange)
-	Return 0
+	; Target lowest health ally
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 1529 - $GC_I_SKILL_ID_PIOUS_RESTORATION
@@ -4572,7 +4746,8 @@ Func BestTarget_RendingTouch($a_f_AggroRange)
 	; Spell. Deals 15...55...65 cold damage to target foe. You lose one Dervish enchantment. If an enchantment was removed, target foe loses 1 enchantment and you gain 1 strike of adrenaline.
 	; Concise description
 	; Touch Spell. Deals 15...55...65 cold damage. Lose 1 Dervish enchantment. Removal effect: target foe loses 1 enchantment and you gain 1 strike of adrenaline.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1545 - $GC_I_SKILL_ID_TEST_OF_FAITH
@@ -4586,7 +4761,10 @@ Func BestTarget_TestOfFaith($a_f_AggroRange)
 	; Spell. Deals 15...55...65 cold damage and takes 1 enchantment from target foe. If that foe was not enchanted, that foe is Dazed for 1...3...4 second[s].
 	; Concise description
 	; Touch Spell. Deals 15...55...65 cold damage and removes 1 enchantment. Target foe is Dazed for 1...3...4 second[s] if that foe was not enchanted.
-	Return 0
+	; Target: Enchanted enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1610 - $GC_I_SKILL_ID_SUMMONING_OF_THE_SCEPTER
@@ -4620,7 +4798,8 @@ Func CanUse_DeathsRetreat()
 EndFunc
 
 Func BestTarget_DeathsRetreat($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1653 - $GC_I_SKILL_ID_SWAP
@@ -4634,7 +4813,8 @@ Func BestTarget_Swap($a_f_AggroRange)
 	; Spell. You and target summoned creature Shadow Step to each other's location.
 	; Concise description
 	; Spell. You and target summoned creature Shadow Step to each other's locations.
-	Return 0
+	; Target: Self (swaps with summoned creature)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 1659 - $GC_I_SKILL_ID_TOXIC_CHILL
@@ -4648,7 +4828,12 @@ Func BestTarget_ToxicChill($a_f_AggroRange)
 	; Elite Spell. Target foe is struck for 15...63...75 cold damage. If that foe is under the effects of a hex or enchantment, that foe becomes Poisoned for 10...22...25 seconds.
 	; Concise description
 	; Elite Spell. Deals 15...63...75 cold damage. Inflicts Poisoned condition (10...22...25 seconds) if target foe is hexed or enchanted.
-	Return 0
+	; Target: Hexed/enchanted enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	$l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1661 - $GC_I_SKILL_ID_GLOWSTONE
@@ -4662,7 +4847,10 @@ Func BestTarget_Glowstone($a_f_AggroRange)
 	; Spell. Send a projectile that strikes for 5...41...50 earth damage if it hits. If this spell hits a weakened  foe, you gain 5 Energy plus 1 Energy for every 2 ranks of Energy Storage.
 	; Concise description
 	; Spell. Projectile: deals 5...41...50 earth damage. You gain 5 Energy plus 1 Energy for every 2 ranks of Energy Storage if target foe is Weakened.
-	Return 0
+	; Target: Weakened enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1662 - $GC_I_SKILL_ID_MIND_BLAST
@@ -4676,7 +4864,8 @@ Func BestTarget_MindBlast($a_f_AggroRange)
 	; Elite Spell. Target foe is struck for 15...51...60 fire damage. If you have more Energy than target foe, you gain 1...7...8 Energy.
 	; Concise description
 	; Elite Spell. Deals 15...51...60 fire damage. You gain 1...7...8 Energy if you have more Energy than target foe.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1664 - $GC_I_SKILL_ID_INVOKE_LIGHTNING
@@ -4690,7 +4879,8 @@ Func BestTarget_InvokeLightning($a_f_AggroRange)
 	; Elite Spell. Target foe and up to two other foes near your target are struck for 10...74...90 lightning damage. This spell has 25% armor penetration.
 	; Concise description
 	; Elite Spell. Deals 10...74...90 lightning damage. Hits two foes near target. 25% armor penetration.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1665 - $GC_I_SKILL_ID_BATTLE_CRY1
@@ -4780,7 +4970,8 @@ Func BestTarget_GlimmerOfLight($a_f_AggroRange)
 	; Elite Spell. Heal target ally for 10...94...115 Health.
 	; Concise description
 	; Elite Spell. Heals for 10...94...115.
-	Return 0
+	; Target: Lowest health ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 1687 - $GC_I_SKILL_ID_ZEALOUS_BENEDICTION
@@ -4794,11 +4985,7 @@ Func BestTarget_ZealousBenediction($a_f_AggroRange)
 	; Elite Spell. Heal target ally for 30...150...180 Health. If target was below 50% Health, you gain 7 Energy.
 	; Concise description
 	; Elite Spell. Heals for 30...150...180. You gain 7 Energy if target ally was below 50% Health.
-	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
-	Local $l_f_Hp = UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP)
-	If $l_i_Target <> 0 And $l_f_Hp < 0.5 Then Return $l_i_Target
-
-	Return 0
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 1691 - $GC_I_SKILL_ID_DISMISS_CONDITION
@@ -4812,7 +4999,11 @@ Func BestTarget_DismissCondition($a_f_AggroRange)
 	; Spell. Remove one condition from target ally. If that ally is under the effects of an enchantment, that ally is healed for 15...63...75 Health.
 	; Concise description
 	; Spell. Removes one condition. Heals for 15...63...75 if target ally is enchanted.
-	Return 0
+	; Target: Conditioned ally (highest priority), fallback to lowest health ally
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsConditioned")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 1692 - $GC_I_SKILL_ID_DIVERT_HEXES
@@ -4826,7 +5017,10 @@ Func BestTarget_DivertHexes($a_f_AggroRange)
 	; Elite Spell. Remove up to 1...3...3 hex[es] from target ally. For each hex removed in this way, that ally loses one condition and gains 15...63...75 Health.
 	; Concise description
 	; Elite Spell. Removes 1...3...3 hex[es]. For each hex removed, target ally loses one condition and gains 15...63...75 Health.
-	Return 0
+	; Target: Hexed ally (support spell)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly")
 EndFunc
 
 ; Skill ID: 1717 - $GC_I_SKILL_ID_SUNSPEAR_SIEGE
@@ -4850,7 +5044,8 @@ Func CanUse_WieldersStrike()
 EndFunc
 
 Func BestTarget_WieldersStrike($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1741 - $GC_I_SKILL_ID_GHOSTMIRROR_LIGHT
@@ -4867,10 +5062,8 @@ Func BestTarget_GhostmirrorLight($a_f_AggroRange)
 	; Spell. Target other ally is healed for 15...75...90 Health. If you are within earshot of a spirit, you are also healed for 15...75...90 Health.
 	; Concise description
 	; Spell. Heals for 15...75...90. You gain 15...75...90 Health if you are within earshot of a spirit. Cannot self-target.
-	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
-	If $l_i_Target <> 0 And UAI_GetAgentInfoByID($l_i_Target, $GC_UAI_AGENT_HP) < 0.8 Then Return $l_i_Target
-
-	Return 0
+	; Target: Lowest health ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 1744 - $GC_I_SKILL_ID_CARETAKERS_CHARGE
@@ -4880,7 +5073,8 @@ Func CanUse_CaretakersCharge()
 EndFunc
 
 Func BestTarget_CaretakersCharge($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1859 - $GC_I_SKILL_ID_ALTAR_BUFF
@@ -4922,7 +5116,10 @@ Func BestTarget_BanishEnchantment($a_f_AggroRange)
 	; Spell. All enchantments are removed from caster's target foe. For each enchantment removed in this way, one skill is disabled on all foes for 6 seconds.
 	; Concise description
 	; Spell. All enchantments are removed from target foe. For each enchantment removed in this way, one skill is disabled on all foes (6 seconds).
-	Return 0
+	; Target: Enchanted enemy (highest priority)
+	Local $l_i_Target = UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 1896 - $GC_I_SKILL_ID_UNYIELDING_ANGUISH
@@ -5006,7 +5203,8 @@ Func BestTarget_PowerLock($a_f_AggroRange)
 	; Spell. If target foe is casting a spell or chant, that skill is interrupted and disabled for an additional 5...11...13 seconds.
 	; Concise description
 	; Spell. Interrupts a spell or chant. Interruption effect: interrupted spell or chant is disabled for +5...11...13 seconds.
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 1995 - $GC_I_SKILL_ID_WASTE_NOT_WANT_NOT
@@ -5016,7 +5214,8 @@ Func CanUse_WasteNotWantNot()
 EndFunc
 
 Func BestTarget_WasteNotWantNot($a_f_AggroRange)
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2003 - $GC_I_SKILL_ID_CURE_HEX
@@ -5044,7 +5243,8 @@ Func BestTarget_SmiteCondition($a_f_AggroRange)
 	; Spell. Remove one condition from target ally. If a condition was removed, foes in the area take 10...50...60 holy damage.
 	; Concise description
 	; Spell. Removes a condition. Removal effect: deals 10...50...60 holy damage to foes in the area of target ally.
-	Return 0
+	; Target: Conditioned ally (support spell)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsConditioned")
 EndFunc
 
 ; Skill ID: 2019 - $GC_I_SKILL_ID_BURNING_GROUND
@@ -5197,7 +5397,10 @@ Func BestTarget_Aneurysm($a_f_AggroRange)
 	; Spell. Target foe regains all Energy. For each point of Energy gained in this way, that foe takes 1...3...3 damage and all adjacent foes lose 1 Energy. (Maximum 1...24...30).
 	; Concise description
 	; Spell. Target foe regains all Energy. For each point of Energy gained, target takes 1...3...3 damage and all adjacent foes lose 1 Energy (maximum 1...24...30).
-	Return 0
+	; Target: Highest energy caster (maximize damage)
+	Local $l_i_Target = UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_Energy, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_Energy, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2057 - $GC_I_SKILL_ID_FOUL_FEAST
@@ -5211,7 +5414,8 @@ Func BestTarget_FoulFeast($a_f_AggroRange)
 	; Spell. All conditions are transferred from target other ally to yourself. For each condition acquired in this way, you gain 0...36...45 Health and 0...2...2 Energy. This skill recharges twice as fast if you remove Disease from your target.
 	; Concise description
 	; Spell. Transfers all conditions from target ally to yourself. You gain 0...36...45 Health and 0...2...2 Energy for each condition transferred. Half recharge if you remove Disease. Cannot self-target.
-	Return 0
+	; Target: Conditioned ally (support spell)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsConditioned")
 EndFunc
 
 ; Skill ID: 2059 - $GC_I_SKILL_ID_SHELL_SHOCK
@@ -5225,7 +5429,8 @@ Func BestTarget_ShellShock($a_f_AggroRange)
 	; Spell. Target foe is struck for 10...26...30 lightning damage and has Cracked Armor for 5...17...20 seconds. This spell has 25% armor penetration. If you are Overcast, this spell strikes adjacent foes.
 	; Concise description
 	; Spell. Deals 10...26...30 lightning damage. Inflicts Cracked Armor condition (5...17...20 seconds). 25% armor penetration. If Overcast, strikes adjacent.
-	Return 0
+	; Target: Grouped enemies (AOE if overcast)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2062 - $GC_I_SKILL_ID_HEALING_RIBBON
@@ -5239,7 +5444,8 @@ Func BestTarget_HealingRibbon($a_f_AggroRange)
 	; Spell. Target other ally is healed for 20...92...110 Health. Up to 2 additional allies near target ally are healed for 10...82...100 Health.
 	; Concise description
 	; Spell. Heals for 20...92...110. Heals two additional allies near target ally for 10...82...100. Cannot self-target.
-	Return 0
+	; Target: Lowest health ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 2076 - $GC_I_SKILL_ID_DRAIN_MINION
@@ -5253,7 +5459,8 @@ Func BestTarget_DrainMinion($a_f_AggroRange)
 	; Spell. Sacrifice target undead servant to gain 300 Health.
 	; Concise description
 	; Spell. Sacrifice target undead servant to gain 300 Health.
-	Return 0
+	; Target: Self (targets own minions)
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 2079 - $GC_I_SKILL_ID_FLESHREAVERS_ESCAPE
@@ -5273,7 +5480,8 @@ Func CanUse_MandragorsCharge()
 EndFunc
 
 Func BestTarget_MandragorsCharge($a_f_AggroRange)
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2084 - $GC_I_SKILL_ID_ROCK_SLIDE
@@ -5311,7 +5519,8 @@ Func BestTarget_CeilingCollapse($a_f_AggroRange)
 	; Spell. Creature causes debris to fall from the ceiling, dealing 50 damage and interrupting all foes within earshot.
 	; Concise description
 	; Spell. Creature causes debris to fall from the ceiling, dealing 50 damage and interrupting all foes within earshot.
-	Return 0
+	; Target: Grouped enemies (AOE interrupt)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2100 - $GC_I_SKILL_ID_SUMMON_SPIRITS_KURZICK
@@ -5346,7 +5555,8 @@ Func BestTarget_CryOfPain($a_f_AggroRange)
 	; Spell. Interrupt target foe's skill. If that foe was suffering from a Mesmer hex, that foe and all foes in the area take 25...50 damage and have 3...5 Health degeneration for 10 seconds.
 	; Concise description
 	; Spell. Interrupts a skill. If target foe had a Mesmer hex, deals 25...50 damage to target and foes in the area and causes 3...5 Health degeneration (10 seconds).
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 2161 - $GC_I_SKILL_ID_GOLEM_FIRE_SHIELD
@@ -5398,7 +5608,8 @@ Func CanUse_RavenSwoopAGateTooFar()
 EndFunc
 
 Func BestTarget_RavenSwoopAGateTooFar($a_f_AggroRange)
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2189 - $GC_I_SKILL_ID_ANGORODONS_GAZE
@@ -5408,7 +5619,8 @@ Func CanUse_AngorodonsGaze()
 EndFunc
 
 Func BestTarget_AngorodonsGaze($a_f_AggroRange)
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2191 - $GC_I_SKILL_ID_SLIPPERY_GROUND
@@ -5422,7 +5634,8 @@ Func BestTarget_SlipperyGround($a_f_AggroRange)
 	; Spell. If target or adjacent foes are Blind or moving, these foes are knocked down. There is a 50% chance of failure with Water Magic less than 5.
 	; Concise description
 	; Spell. Causes knock-down if this foe is Blind or moving. Affects foes adjacent to your target. 50% failure chance unless Water Magic greater than 4.
-	Return 0
+	; Target: Grouped enemies (AOE knockdown)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2192 - $GC_I_SKILL_ID_GLOWING_ICE
@@ -5436,7 +5649,10 @@ Func BestTarget_GlowingIce($a_f_AggroRange)
 	; Spell. Target foe is struck for 5...41...50 cold damage. If that foe is under the effects of a Water Magic hex, you gain 5 Energy plus 1 Energy for every 2 ranks of Energy Storage.
 	; Concise description
 	; Spell. Deals 5...41...50 cold damage. You gain 5 Energy plus 1 Energy for every 2 ranks of Energy Storage if target foe is hexed with Water Magic.
-	Return 0
+	; Target: Hexed enemy (highest priority)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2193 - $GC_I_SKILL_ID_ENERGY_BLAST
@@ -5450,7 +5666,8 @@ Func BestTarget_EnergyBlast($a_f_AggroRange)
 	; This article is about the Elementalist skill. For the monster skill of the same name, see Energy Blast (golem).
 	; Concise description
 	; green; font-weight: bold;">1...2...2
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2202 - $GC_I_SKILL_ID_MENDING_GRIP
@@ -5464,7 +5681,8 @@ Func BestTarget_MendingGrip($a_f_AggroRange)
 	; Spell. Target ally is healed for 15...63...75 Health. If that ally is under the effects of a weapon spell, that ally loses one condition.
 	; Concise description
 	; Spell. Heals for 15...63...75. Removes one condition if target ally is under a Weapon [sic] spell.
-	Return 0
+	; Target: Lowest health ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 2211 - $GC_I_SKILL_ID_ALKARS_ALCHEMICAL_ACID
@@ -5474,7 +5692,8 @@ Func CanUse_AlkarsAlchemicalAcid()
 EndFunc
 
 Func BestTarget_AlkarsAlchemicalAcid($a_f_AggroRange)
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2212 - $GC_I_SKILL_ID_LIGHT_OF_DELDRIMOR
@@ -5614,7 +5833,8 @@ Func BestTarget_EbonVanguardSniperSupport($a_f_AggroRange)
 	; Spell. Target foe is struck for 54...90 piercing damage and begins Bleeding for 5...25 seconds. This attack has a 10% chance of doing an additional +540...900 piercing damage. If this attack hits a Charr it has a 25% chance of doing an additional +540...900 piercing damage.
 	; Concise description
 	; Spell. Deals 54...90 piercing damage and inflicts Bleeding condition (5...25 seconds). 10% chance of +540...900 piercing damage. 25% chance of +540...900 piercing damage if target foe is a Charr.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2235 - $GC_I_SKILL_ID_EBON_VANGUARD_ASSASSIN_SUPPORT
@@ -5661,7 +5881,8 @@ Func BestTarget_PolymockPowerDrain($a_f_AggroRange)
 	; Spell. If target foe is casting a spell or glyph, that foe is interrupted and you gain 3 Energy.
 	; Concise description
 	; Spell. Interrupts a spell or glyph. Interruption effect: you gain 3 Energy.
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 2253 - $GC_I_SKILL_ID_POLYMOCK_OVERLOAD
@@ -5675,7 +5896,10 @@ Func BestTarget_PolymockOverload($a_f_AggroRange)
 	; Spell. Target foe takes 100 damage. If that foe was casting a spell, you deal +50 damage.
 	; Concise description
 	; Spell. Deals 100 damage. Deals 50 more damage if target foe was casting a spell.
-	Return 0
+	; Target: Casting enemy (bonus damage)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2256 - $GC_I_SKILL_ID_ORDER_OF_UNHOLY_VIGOR
@@ -5745,7 +5969,8 @@ Func BestTarget_PolymockDeathlyChill($a_f_AggroRange)
 	; Spell. Target foe is struck for 100 damage. If that foe is above 50% Health, you deal an additional 50 damage.
 	; Concise description
 	; Spell. Deals 100 damage. Deals 50 more damage if target foe's Health is above 50%.
-	Return 0
+	; Target: Highest health enemy (bonus damage)
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2262 - $GC_I_SKILL_ID_POLYMOCK_ROTTING_FLESH
@@ -5759,7 +5984,8 @@ Func BestTarget_PolymockRottingFlesh($a_f_AggroRange)
 	; Spell. Target foe becomes Diseased for 20 seconds and slowly loses Health.
 	; Concise description
 	; Spell. Inflicts Diseased condition (20 seconds). Disease causes -4 Health degeneration.
-	Return 0
+	; Target: Nearest enemy (condition application)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2263 - $GC_I_SKILL_ID_POLYMOCK_LIGHTNING_STRIKE
@@ -5773,7 +5999,8 @@ Func BestTarget_PolymockLightningStrike($a_f_AggroRange)
 	; Spell. Strike target foe for 120 damage.
 	; Concise description
 	; Spell. Deals 120 damage.
-	Return 0
+	; Target: Lowest health enemy (damage priority)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2264 - $GC_I_SKILL_ID_POLYMOCK_LIGHTNING_ORB
@@ -5787,7 +6014,8 @@ Func BestTarget_PolymockLightningOrb($a_f_AggroRange)
 	; Spell. Send out a Lightning Orb that strikes target foe for 800 damage if it hits.
 	; Concise description
 	; Spell. Projectile: deals 800 damage.
-	Return 0
+	; Target: Lowest health enemy (damage priority)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2266 - $GC_I_SKILL_ID_POLYMOCK_FLARE
@@ -5801,7 +6029,8 @@ Func BestTarget_PolymockFlare($a_f_AggroRange)
 	; Spell. Send out a Flare that strikes target foe for 120 damage if it hits.
 	; Concise description
 	; Spell. Projectile: deals 120 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2267 - $GC_I_SKILL_ID_POLYMOCK_IMMOLATE
@@ -5815,7 +6044,8 @@ Func BestTarget_PolymockImmolate($a_f_AggroRange)
 	; Spell. Target foe is set on fire for 20 seconds.
 	; Concise description
 	; Spell. Inflicts Burning condition (20 seconds). Burning causes -7 Health degeneration.
-	Return 0
+	; Target: Nearest enemy (condition application)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2268 - $GC_I_SKILL_ID_POLYMOCK_METEOR
@@ -5829,7 +6059,10 @@ Func BestTarget_PolymockMeteor($a_f_AggroRange)
 	; Spell. Target foe is struck for 600 damage. If that foe is casting a spell, that spell is interrupted.
 	; Concise description
 	; Spell. Deals 600 damage. Interrupts a spell.
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2269 - $GC_I_SKILL_ID_POLYMOCK_ICE_SPEAR
@@ -5843,7 +6076,8 @@ Func BestTarget_PolymockIceSpear($a_f_AggroRange)
 	; Spell. Send out an Ice Spear, striking target foe for 120 damage if it hits.
 	; Concise description
 	; Spell. Projectile: deals 120 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2270 - $GC_I_SKILL_ID_POLYMOCK_ICY_PRISON
@@ -5857,7 +6091,8 @@ Func BestTarget_PolymockIcyPrison($a_f_AggroRange)
 	; Polymock skill
 	; Concise description
 	; disables interrupted spell (5 seconds).
-	Return 0
+	; Target: Casting enemy (interrupt priority)
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
 EndFunc
 
 ; Skill ID: 2271 - $GC_I_SKILL_ID_POLYMOCK_MIND_FREEZE
@@ -5871,7 +6106,8 @@ Func BestTarget_PolymockMindFreeze($a_f_AggroRange)
 	; Spell. Target foe suffers 400 damage. If you have more Energy than target foe, that foe suffers an additional 400 damage.
 	; Concise description
 	; Spell. Deals 400 damage. Deals 400 more damage if you have more Energy than target foe.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2272 - $GC_I_SKILL_ID_POLYMOCK_ICE_SHARD_STORM
@@ -5885,7 +6121,8 @@ Func BestTarget_PolymockIceShardStorm($a_f_AggroRange)
 	; Spell. Target foe begins Bleeding for 20 seconds.
 	; Concise description
 	; Spell. Inflicts Bleeding condition (20 seconds). Bleeding causes -3 Health degeneration.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2273 - $GC_I_SKILL_ID_POLYMOCK_FROZEN_TRIDENT
@@ -5899,7 +6136,10 @@ Func BestTarget_PolymockFrozenTrident($a_f_AggroRange)
 	; Spell. Send out a fast-moving Frozen Trident that strikes target foe for 600 damage if it hits. If target foe is casting a spell, that spell is interrupted.
 	; Concise description
 	; Spell. Fast projectile: deals 600 damage. Interrupts a spell.
-	Return 0
+	; Target: Casting enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2274 - $GC_I_SKILL_ID_POLYMOCK_SMITE
@@ -5913,7 +6153,8 @@ Func BestTarget_PolymockSmite($a_f_AggroRange)
 	; Spell. Target foe takes 120 damage.
 	; Concise description
 	; Spell. Deals 120 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2275 - $GC_I_SKILL_ID_POLYMOCK_SMITE_HEX
@@ -5927,7 +6168,8 @@ Func BestTarget_PolymockSmiteHex($a_f_AggroRange)
 	; Spell. Remove the last hex placed upon you. If a hex is removed, your enemy takes 400 damage.
 	; Concise description
 	; Spell. Remove the last hex placed upon you. Removal effect: deals 400 damage to your foe.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2277 - $GC_I_SKILL_ID_POLYMOCK_STONE_DAGGERS
@@ -5941,7 +6183,8 @@ Func BestTarget_PolymockStoneDaggers($a_f_AggroRange)
 	; Spell. Send out two Stone Daggers. Each Stone Dagger strikes target foe for 60 damage if it hits.
 	; Concise description
 	; Spell. Two projectiles: deals 60 damage each.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2278 - $GC_I_SKILL_ID_POLYMOCK_OBSIDIAN_FLAME
@@ -5955,7 +6198,8 @@ Func BestTarget_PolymockObsidianFlame($a_f_AggroRange)
 	; Spell. Target foe takes 800 damage.
 	; Concise description
 	; Spell. Deals 800 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2279 - $GC_I_SKILL_ID_POLYMOCK_EARTHQUAKE
@@ -5969,7 +6213,10 @@ Func BestTarget_PolymockEarthquake($a_f_AggroRange)
 	; Spell. You invoke an Earthquake at target foe's location. Target foe is struck for 650 damage. If that foe is casting a spell, that spell is interrupted.
 	; Concise description
 	; Spell. Interrupts a spell. Deals 650 damage.
-	Return 0
+	; Target: Casting enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2282 - $GC_I_SKILL_ID_POLYMOCK_FIREBALL
@@ -5983,7 +6230,8 @@ Func BestTarget_PolymockFireball($a_f_AggroRange)
 	; Spell. Send out a ball of fire that strikes target foe for 800 damage if it hits.
 	; Concise description
 	; Spell. Projectile: deals 800 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2283 - $GC_I_SKILL_ID_POLYMOCK_RODGORTS_INVOCATION
@@ -5993,7 +6241,8 @@ Func CanUse_PolymockRodgortsInvocation()
 EndFunc
 
 Func BestTarget_PolymockRodgortsInvocation($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2288 - $GC_I_SKILL_ID_POLYMOCK_LAMENTATION
@@ -6007,7 +6256,8 @@ Func BestTarget_PolymockLamentation($a_f_AggroRange)
 	; Spell. Strike target foe for 120 damage.
 	; Concise description
 	; Spell. Deals 120 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2289 - $GC_I_SKILL_ID_POLYMOCK_SPIRIT_RIFT
@@ -6021,7 +6271,8 @@ Func BestTarget_PolymockSpiritRift($a_f_AggroRange)
 	; Spell. Open a Spirit Rift at target foe's location. After 3 seconds, that foe is struck for 850 damage.
 	; Concise description
 	; Spell. Open a Spirit Rift at target foe's location. Deals 850 damage after 3 seconds.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2293 - $GC_I_SKILL_ID_POLYMOCK_GLOWING_GAZE
@@ -6035,7 +6286,10 @@ Func BestTarget_PolymockGlowingGaze($a_f_AggroRange)
 	; Spell. Target foe takes 150 damage. If that foe is on fire, you gain 6 Energy.
 	; Concise description
 	; Spell. Deals 150 damage. You gain 6 Energy if target foe is Burning.
-	Return 0
+	; Target: Burning enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsBurning")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2294 - $GC_I_SKILL_ID_POLYMOCK_SEARING_FLAMES
@@ -6049,7 +6303,10 @@ Func BestTarget_PolymockSearingFlames($a_f_AggroRange)
 	; Spell. Target foe is struck with Searing Flames. If that foe is already on fire, that foe takes 800 damage. Otherwise, that foe begins Burning for 5 seconds.
 	; Concise description
 	; Spell. Deals 800 damage if target foe is Burning. Otherwise, that foe begins Burning (5 seconds). Burning causes -7 Health degeneration.
-	Return 0
+	; Target: Burning enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsBurning")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2297 - $GC_I_SKILL_ID_POLYMOCK_STONING
@@ -6063,7 +6320,8 @@ Func BestTarget_PolymockStoning($a_f_AggroRange)
 	; Spell. Send out a large stone, striking target foe for 800 damage if it hits.
 	; Concise description
 	; Spell. Projectile: 800 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2298 - $GC_I_SKILL_ID_POLYMOCK_ERUPTION
@@ -6077,7 +6335,8 @@ Func BestTarget_PolymockEruption($a_f_AggroRange)
 	; Spell. Cause an eruption at target foe's location. Target foe takes 400 damage and all of that foe's glyphs are disabled for 15 seconds.
 	; Concise description
 	; Spell. Deals 400 damage and disables all of target foe's glyphs (15 seconds).
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2299 - $GC_I_SKILL_ID_POLYMOCK_SHOCK_ARROW
@@ -6091,7 +6350,8 @@ Func BestTarget_PolymockShockArrow($a_f_AggroRange)
 	; Spell. Send out a Shock Arrow that flies swiftly toward target foe, striking for 150 damage if it hits. If target foe is using a glyph, that foe takes 200 additional damage.
 	; Concise description
 	; Spell. Fast projectile: deals 150 damage. Deals 200 more damage if target foe is using a glyph.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2300 - $GC_I_SKILL_ID_POLYMOCK_MIND_SHOCK
@@ -6105,7 +6365,8 @@ Func BestTarget_PolymockMindShock($a_f_AggroRange)
 	; Spell. Target foe suffers 400 damage. If you have more Energy than target foe, that foe suffers an additional 400 damage.
 	; Concise description
 	; Spell. Deals 400 damage. Deals 400 more damage if you have more Energy than target foe.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2301 - $GC_I_SKILL_ID_POLYMOCK_PIERCING_LIGHT_SPEAR
@@ -6119,7 +6380,8 @@ Func BestTarget_PolymockPiercingLightSpear($a_f_AggroRange)
 	; Spell. A Piercing Light Spear flies toward target foe and causes Bleeding for 20 seconds if it hits.
 	; Concise description
 	; Spell. Projectile: inflicts Bleeding condition (20 seconds). Bleeding causes -3 Health degeneration.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2302 - $GC_I_SKILL_ID_POLYMOCK_MIND_BLAST
@@ -6133,7 +6395,8 @@ Func BestTarget_PolymockMindBlast($a_f_AggroRange)
 	; Spell. Target foe suffers 300 damage. If you have less Energy than target foe, you gain 8 Energy.
 	; Concise description
 	; Spell. Deals 300 damage. Gain 8 Energy if you have less Energy than target foe.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2303 - $GC_I_SKILL_ID_POLYMOCK_SAVANNAH_HEAT
@@ -6147,7 +6410,8 @@ Func BestTarget_PolymockSavannahHeat($a_f_AggroRange)
 	; Spell. You create Savannah Heat at target foe's location. For 5 seconds, that foe takes 100 damage each second and an additional 50 damage for each second this spell has been in effect.
 	; Concise description
 	; Spell. Deals 100 damage each second (5 seconds) at target foe's location. Deals 50 more damage for each second since casting this spell.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2305 - $GC_I_SKILL_ID_POLYMOCK_LIGHTNING_BLAST
@@ -6161,7 +6425,8 @@ Func BestTarget_PolymockLightningBlast($a_f_AggroRange)
 	; Spell. Target foe is struck for 800 damage.
 	; Concise description
 	; Spell. Deals 800 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2306 - $GC_I_SKILL_ID_POLYMOCK_POISONED_GROUND
@@ -6175,7 +6440,8 @@ Func BestTarget_PolymockPoisonedGround($a_f_AggroRange)
 	; Spell. Target foe becomes Poisoned for 20 seconds.
 	; Concise description
 	; Spell. Inflicts Poisoned condition (20 seconds). Poison causes -4 Health degeneration.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2308 - $GC_I_SKILL_ID_POLYMOCK_SANDSTORM
@@ -6189,7 +6455,10 @@ Func BestTarget_PolymockSandstorm($a_f_AggroRange)
 	; Spell. Create a Sandstorm at target foe's location. For 10 seconds, target foe is struck for 40 damage each second. If that foe is casting a spell, that foe takes an additional 20 damage each second.
 	; Concise description
 	; Spell. Deals 40 damage each second at target foe's location (10 seconds). Deals 20 more damage each second if that foe is casting a spell.
-	Return 0
+	; Target: Casting enemy (highest priority), fallback to nearest enemy
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCasting")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2309 - $GC_I_SKILL_ID_POLYMOCK_BANISH
@@ -6203,7 +6472,8 @@ Func BestTarget_PolymockBanish($a_f_AggroRange)
 	; Spell. Target foe takes 800 damage.
 	; Concise description
 	; Spell. Deals 800 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2368 - $GC_I_SKILL_ID_MURAKAIS_CONSUMPTION
@@ -6213,7 +6483,8 @@ Func CanUse_MurakaisConsumption()
 EndFunc
 
 Func BestTarget_MurakaisConsumption($a_f_AggroRange)
-	Return 0
+	; Target lowest health ally
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 2369 - $GC_I_SKILL_ID_MURAKAIS_CENSURE
@@ -6257,7 +6528,8 @@ Func BestTarget_RavenSwoop($a_f_AggroRange)
 	; Spell. Strike target foe and all adjacent foes for 60...100 damage.
 	; Concise description
 	; Spell. Deals 60...100 damage. Also hits adjacent foes.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2390 - $GC_I_SKILL_ID_FILTHY_EXPLOSION
@@ -6309,7 +6581,8 @@ Func BestTarget_SmoothCriminal($a_f_AggroRange)
 	; Spell. For 10...20 seconds, one random spell is disabled for target foe and Smooth Criminal is replaced by that spell. You gain 5...10 Energy.
 	; Concise description
 	; Spell. (10...20 seconds.) Disables one Spell. This skill becomes that Spell. You gain 5...10 Energy.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2413 - $GC_I_SKILL_ID_TECHNOBABBLE
@@ -6323,7 +6596,8 @@ Func BestTarget_Technobabble($a_f_AggroRange)
 	; Spell. Target foe and all adjacent foes are struck for 30...40 damage. If target foe is not a boss, that foe and all adjacent foes are Dazed for 3...5 seconds.
 	; Concise description
 	; Spell. Deals 30...40 damage to target and adjacent foes. Inflicts Dazed condition (3...5 seconds) on these foes if target was not a boss.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2420 - $GC_I_SKILL_ID_EBON_ESCAPE
@@ -6337,6 +6611,9 @@ Func BestTarget_EbonEscape($a_f_AggroRange)
 	; Spell. Shadow Step to target other ally. You and that other ally are healed for 70...110 health.
 	; Concise description
 	; Spell. Heals you and target ally for 70...110. Initial effect: Shadow Step to this ally. Cannot self-target.
+	; Target: Lowest health ally (support spell, cannot self-target)
+	Local $l_i_Target = UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
+	If $l_i_Target <> 0 Then Return $l_i_Target
 	Return 0
 EndFunc
 
@@ -6347,7 +6624,8 @@ Func CanUse_DrydersFeast()
 EndFunc
 
 Func BestTarget_DrydersFeast($a_f_AggroRange)
-	Return 0
+	; Target lowest health ally
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 2517 - $GC_I_SKILL_ID_REVERSE_POLARITY_FIRE_SHIELD
@@ -6401,7 +6679,8 @@ Func CanUse_WurmSiegeEyeOfTheNorth()
 EndFunc
 
 Func BestTarget_WurmSiegeEyeOfTheNorth($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2626 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -6412,7 +6691,8 @@ Func CanUse_Enfeeble2()
 EndFunc
 
 Func BestTarget_Enfeeble2($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2629 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -6423,7 +6703,8 @@ Func CanUse_SearingFlames2()
 EndFunc
 
 Func BestTarget_SearingFlames2($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2633 - $GC_I_SKILL_ID_GLOWING_GAZE2
@@ -6433,7 +6714,8 @@ Func CanUse_GlowingGaze2()
 EndFunc
 
 Func BestTarget_GlowingGaze2($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2634 - $GC_I_SKILL_ID_STEAM2
@@ -6443,7 +6725,8 @@ Func CanUse_Steam2()
 EndFunc
 
 Func BestTarget_Steam2($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2636 - $GC_I_SKILL_ID_LIQUID_FLAM2
@@ -6453,7 +6736,8 @@ Func CanUse_LiquidFlam2()
 EndFunc
 
 Func BestTarget_LiquidFlam2($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2637 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -6464,7 +6748,8 @@ Func CanUse_SmiteCondition2()
 EndFunc
 
 Func BestTarget_SmiteCondition2($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2664 - $GC_I_SKILL_ID_SPIKE_TRAP_SPELL
@@ -6487,8 +6772,9 @@ Func BestTarget_FireAndBrimstone($a_f_AggroRange)
 	; Description
 	; Monster skill
 	; Concise description
-	; "en","wgPageContentModel":"wikitext","wgRelevantPageName":"Fire_and_Brimstone","wgRelevantArticleId":230825,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgMFDisplayWikibaseDescriptions":{"search":false,"nearby":false,"watchlist":false,"tagline":false},"wgPopupsFlags":4,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true}; RLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready","user.options":"loading","skins.monobook.styles":"ready"};RLPAGEMODULES=["site","mediawiki.page.ready","skins.monobook.scripts","mmv.head","mmv.bootstrap.autostart","ext.popups"];
-	Return 0
+	; Notes">edit
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2686 - $GC_I_SKILL_ID_ESSENCE_STRIKE_TOGO
@@ -6498,7 +6784,8 @@ Func CanUse_EssenceStrikeTogo()
 EndFunc
 
 Func BestTarget_EssenceStrikeTogo($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2687 - $GC_I_SKILL_ID_SPIRIT_BURN_TOGO
@@ -6508,7 +6795,8 @@ Func CanUse_SpiritBurnTogo()
 EndFunc
 
 Func BestTarget_SpiritBurnTogo($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2688 - $GC_I_SKILL_ID_SPIRIT_RIFT_TOGO
@@ -6518,7 +6806,8 @@ Func CanUse_SpiritRiftTogo()
 EndFunc
 
 Func BestTarget_SpiritRiftTogo($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2689 - $GC_I_SKILL_ID_MEND_BODY_AND_SOUL_TOGO
@@ -6528,7 +6817,8 @@ Func CanUse_MendBodyAndSoulTogo()
 EndFunc
 
 Func BestTarget_MendBodyAndSoulTogo($a_f_AggroRange)
-	Return 0
+	; Target lowest health ally
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 2690 - $GC_I_SKILL_ID_OFFERING_OF_SPIRIT_TOGO
@@ -6552,7 +6842,8 @@ Func BestTarget_RedemptionOfPurity($a_f_AggroRange)
 	; Spell. Destroy target minion. That minion is replaced with a level 12 Spirit of Pain. This Spirit deals 30 damage. This Spirit dies after 150 seconds.
 	; Concise description
 	; Spell. Target minion is destroyed and replaced with a level 12 Spirit of Pain. This spirit deals 30 damage and dies after 150 seconds.
-	Return 0
+	; Target: Nearest enemy minion
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2723 - $GC_I_SKILL_ID_PURIFY_ENERGY
@@ -6594,7 +6885,10 @@ Func BestTarget_PurifyingPrayer($a_f_AggroRange)
 	; Spell. Removes 2...4...4 hexes and 2...4...4 conditions from target ally. For each hex removed, 1 foe near target ally loses an enchantment.
 	; Concise description
 	; Spell. Removes 2...4...4 hexes and 2...4...4 conditions from target ally. For each hex removed, 1 foe near target ally loses an enchantment.
-	Return 0
+	; Target: Hexed/conditioned ally (support spell)
+	Local $l_i_Target = UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly|UAI_Filter_IsConditioned|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsAlly")
 EndFunc
 
 ; Skill ID: 2729 - $GC_I_SKILL_ID_PURIFY_SOUL
@@ -6632,7 +6926,8 @@ Func CanUse_RocketPropelledGobstopper()
 EndFunc
 
 Func BestTarget_RocketPropelledGobstopper($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2760 - $GC_I_SKILL_ID_RAIN_OF_TERROR_SPELL
@@ -6642,7 +6937,8 @@ Func CanUse_RainOfTerrorSpell()
 EndFunc
 
 Func BestTarget_RainOfTerrorSpell($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2762 - $GC_I_SKILL_ID_SUGAR_INFUSION
@@ -6656,7 +6952,8 @@ Func BestTarget_SugarInfusion($a_f_AggroRange)
 	; Spell. Sacrifice 25% of your current Health. Target other ally is healed for 150% of the amount you lost. If this targets Mad King Thorn, this spell heals for 200% the amount you lost.
 	; Concise description
 	; Spell. Heal target ally for 150% of your Health sacrifice. If targeting Mad King Thorn, heal for 200% of your Health sacrifice. You lose a quarter of your current health. Cannot Self Target.
-	Return 0
+	; Target: Lowest health ally (support spell, cannot self-target)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 2763 - $GC_I_SKILL_ID_FEAST_OF_VENGEANCE
@@ -6670,7 +6967,8 @@ Func BestTarget_FeastOfVengeance($a_f_AggroRange)
 	; Spell. Steal 150 Health from target foe.
 	; Concise description
 	; Spell. You steal 150 Health from target foe.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2764 - $GC_I_SKILL_ID_ANIMATE_CANDY_MINIONS
@@ -6698,7 +6996,8 @@ Func BestTarget_TasteOfUndeath($a_f_AggroRange)
 	; Monster
 	; Concise description
 	; Related skills">edit
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2766 - $GC_I_SKILL_ID_SCOURGE_OF_CANDY
@@ -6712,7 +7011,8 @@ Func BestTarget_ScourgeOfCandy($a_f_AggroRange)
 	; Monster
 	; Concise description
 	; Related skills">edit
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2768 - $GC_I_SKILL_ID_MAD_KING_PONY_SUPPORT
@@ -6726,7 +7026,8 @@ Func BestTarget_MadKingPonySupport($a_f_AggroRange)
 	; Elite Spell. Summon a level 20 Invisible Pony. This summoned pony prances to target foe. This pony lasts 60 seconds.
 	; Concise description
 	; Elite Spell. Summon a level 20 Invisible Pony. This summoned pony prances to target foe. This pony lasts 60 seconds.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2789 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -6741,7 +7042,8 @@ Func CanUse_MindShockPvp()
 EndFunc
 
 Func BestTarget_MindShockPvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2807 - $GC_I_SKILL_ID_RIDE_THE_LIGHTNING_PVP
@@ -6751,7 +7053,8 @@ Func CanUse_RideTheLightningPvp()
 EndFunc
 
 Func BestTarget_RideTheLightningPvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2809 - $GC_I_SKILL_ID_OBSIDIAN_FLAME_PVP
@@ -6761,7 +7064,8 @@ Func CanUse_ObsidianFlamePvp()
 EndFunc
 
 Func BestTarget_ObsidianFlamePvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2833 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -6774,7 +7078,10 @@ Func CanUse_EnergyDrainPvp()
 EndFunc
 
 Func BestTarget_EnergyDrainPvp($a_f_AggroRange)
-	Return 0
+	; Target highest health caster
+	Local $l_i_Target = UAI_GetBestSingleTarget(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestSingleTarget(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2853 - $GC_I_SKILL_ID_ENERGY_TAP_PVP
@@ -6784,7 +7091,10 @@ Func CanUse_EnergyTapPvp()
 EndFunc
 
 Func BestTarget_EnergyTapPvp($a_f_AggroRange)
-	Return 0
+	; Target highest health caster
+	Local $l_i_Target = UAI_GetBestSingleTarget(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsCaster")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestSingleTarget(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2856 - $GC_I_SKILL_ID_LIGHTNING_ORB_PVP
@@ -6794,7 +7104,8 @@ Func CanUse_LightningOrbPvp()
 EndFunc
 
 Func BestTarget_LightningOrbPvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2859 - $GC_I_SKILL_ID_ENFEEBLE_PVP
@@ -6804,7 +7115,8 @@ Func CanUse_EnfeeblePvp()
 EndFunc
 
 Func BestTarget_EnfeeblePvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2863 - $GC_I_SKILL_ID_DISCORD_PVP
@@ -6814,7 +7126,8 @@ Func CanUse_DiscordPvp()
 EndFunc
 
 Func BestTarget_DiscordPvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2866 - $GC_I_SKILL_ID_FLESH_OF_MY_FLESH_PVP
@@ -6825,7 +7138,8 @@ Func CanUse_FleshOfMyFleshPvp()
 EndFunc
 
 Func BestTarget_FleshOfMyFleshPvp($a_f_AggroRange)
-	Return 0
+	; Target lowest health ally
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 2870 - $GC_I_SKILL_ID_BLINDING_SURGE_PVP
@@ -6835,7 +7149,8 @@ Func CanUse_BlindingSurgePvp()
 EndFunc
 
 Func BestTarget_BlindingSurgePvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2871 - $GC_I_SKILL_ID_LIGHT_OF_DELIVERANCE_PVP
@@ -6856,7 +7171,8 @@ Func CanUse_EnfeeblingBloodPvp()
 EndFunc
 
 Func BestTarget_EnfeeblingBloodPvp($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_NEARBY, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2902 - $GC_I_SKILL_ID_REACTOR_BLAST
@@ -6880,7 +7196,8 @@ Func CanUse_NoxBeam()
 EndFunc
 
 Func BestTarget_NoxBeam($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2909 - $GC_I_SKILL_ID_NOXION_BUSTER
@@ -6890,7 +7207,8 @@ Func CanUse_NoxionBuster()
 EndFunc
 
 Func BestTarget_NoxionBuster($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2911 - $GC_I_SKILL_ID_BIT_GOLEM_BREAKER
@@ -6904,7 +7222,8 @@ Func BestTarget_BitGolemBreaker($a_f_AggroRange)
 	; Spell. Launch a projectile that strikes target foe for 30 damage and inflicts a random condition for 15 seconds.
 	; Concise description
 	; Spell. Projectile: 30 damage and inflicts a random condition (15 seconds).
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2913 - $GC_I_SKILL_ID_BIT_GOLEM_CRASH
@@ -6942,7 +7261,8 @@ Func CanUse_NoxThunder()
 EndFunc
 
 Func BestTarget_NoxThunder($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2920 - $GC_I_SKILL_ID_NOX_FIRE
@@ -6962,7 +7282,8 @@ Func CanUse_NoxKnuckle()
 EndFunc
 
 Func BestTarget_NoxKnuckle($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2922 - $GC_I_SKILL_ID_NOX_DIVIDER_DRIVE
@@ -6972,7 +7293,8 @@ Func CanUse_NoxDividerDrive()
 EndFunc
 
 Func BestTarget_NoxDividerDrive($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 2927 - $GC_I_SKILL_ID_SHRINE_BACKLASH
@@ -7031,7 +7353,8 @@ Func CanUse_Snowball2()
 EndFunc
 
 Func BestTarget_Snowball2($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3021 - $GC_I_SKILL_ID_SAVANNAH_HEAT_PVP
@@ -7041,7 +7364,8 @@ Func CanUse_SavannahHeatPvp()
 EndFunc
 
 Func BestTarget_SavannahHeatPvp($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3044 - $GC_I_SKILL_ID_SPIRIT_SIPHON_MASTER_RIYO
@@ -7051,7 +7375,8 @@ Func CanUse_SpiritSiphonMasterRiyo()
 EndFunc
 
 Func BestTarget_SpiritSiphonMasterRiyo($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3058 - $GC_I_SKILL_ID_UNHOLY_FEAST_PVP
@@ -7071,7 +7396,8 @@ Func CanUse_EverlastingMobstopperSkill()
 EndFunc
 
 Func BestTarget_EverlastingMobstopperSkill($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 3078 - $GC_I_SKILL_ID_CURSE_OF_DHUUM
@@ -7161,7 +7487,8 @@ Func BestTarget_SpiritualHealing($a_f_AggroRange)
 	; Spell. Heal target other ally for 250 Health.
 	; Concise description
 	; Spell. Heals for 250 Health. Cannot self-target.
-	Return 0
+	; Target: Lowest health ally (support spell, cannot self-target)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 3089 - $GC_I_SKILL_ID_ENCASE_SKELETAL
@@ -7174,8 +7501,9 @@ Func BestTarget_EncaseSkeletal($a_f_AggroRange)
 	; Description
 	; Spirit Form skill
 	; Concise description
-	; "en","wgPageContentModel":"wikitext","wgRelevantPageName":"Encase_Skeletal","wgRelevantArticleId":228642,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgMFDisplayWikibaseDescriptions":{"search":false,"nearby":false,"watchlist":false,"tagline":false},"wgPopupsFlags":4,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true}; RLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready","user.options":"loading","skins.monobook.styles":"ready"};RLPAGEMODULES=["site","mediawiki.page.ready","skins.monobook.scripts","mmv.head","mmv.bootstrap.autostart","ext.popups"];
-	Return 0
+	; Notes">edit
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3090 - $GC_I_SKILL_ID_REVERSAL_OF_DEATH
@@ -7189,7 +7517,8 @@ Func BestTarget_ReversalOfDeath($a_f_AggroRange)
 	; Spell. Remove 5% Death Penalty from target other ally.
 	; Concise description
 	; Spell. Remove 5% Death Penalty. Cannot self-target.
-	Return 0
+	; Target: Lowest health ally (support spell, cannot self-target)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 3091 - $GC_I_SKILL_ID_GHOSTLY_FURY
@@ -7202,8 +7531,9 @@ Func BestTarget_GhostlyFury($a_f_AggroRange)
 	; Description
 	; Spirit Form skill
 	; Concise description
-	; "en","wgPageContentModel":"wikitext","wgRelevantPageName":"Ghostly_Fury","wgRelevantArticleId":228646,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgMFDisplayWikibaseDescriptions":{"search":false,"nearby":false,"watchlist":false,"tagline":false},"wgPopupsFlags":4,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true}; RLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready","user.options":"loading","skins.monobook.styles":"ready"};RLPAGEMODULES=["site","mediawiki.page.ready","skins.monobook.scripts","mmv.head","mmv.bootstrap.autostart","ext.popups"];
-	Return 0
+	; Notes">edit
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3135 - $GC_I_SKILL_ID_SPIRITUAL_HEALING_REAPER_SKILL
@@ -7213,7 +7543,8 @@ Func CanUse_SpiritualHealingReaperSkill()
 EndFunc
 
 Func BestTarget_SpiritualHealingReaperSkill($a_f_AggroRange)
-	Return 0
+	; Target lowest health ally
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly|UAI_Filter_ExcludeMe")
 EndFunc
 
 ; Skill ID: 3136 - $GC_I_SKILL_ID_GHOSTLY_FURY_REAPER_SKILL
@@ -7223,7 +7554,8 @@ Func CanUse_GhostlyFuryReaperSkill()
 EndFunc
 
 Func BestTarget_GhostlyFuryReaperSkill($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3165 - $GC_I_SKILL_ID_GOLEM_PILEBUNKER
@@ -7236,8 +7568,9 @@ Func BestTarget_GolemPilebunker($a_f_AggroRange)
 	; Description
 	; Spell
 	; Concise description
-	; 20251201191736 Cache expiry: 86400 Reduced expiry: false Complications: [] CPU time usage: 0.015 seconds Real time usage: 0.023 seconds Preprocessor visited node count: 285/1000000 Post‐expand include size: 1904/2097152 bytes Template argument size: 618/2097152 bytes Highest expansion depth: 7/100 Expensive parser function count: 0/100 Unstrip recursion depth: 0/20 Unstrip post‐expand size: 0/5000000 bytes ExtLoops count: 0/1000 -->
-	Return 0
+	; Notes">edit
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3167 - ;  $GC_I_SKILL_ID_UNKNOWN
@@ -7250,7 +7583,8 @@ Func CanUse_KorosGaze()
 EndFunc
 
 Func BestTarget_KorosGaze($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3171 - $GC_I_SKILL_ID_EBON_VANGUARD_ASSASSIN_SUPPORT_NPC
@@ -7260,7 +7594,8 @@ Func CanUse_EbonVanguardAssassinSupportNpc()
 EndFunc
 
 Func BestTarget_EbonVanguardAssassinSupportNpc($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3180 - $GC_I_SKILL_ID_SHATTER_DELUSIONS_PVP
@@ -7270,7 +7605,10 @@ Func CanUse_ShatterDelusionsPvp()
 EndFunc
 
 Func BestTarget_ShatterDelusionsPvp($a_f_AggroRange)
-	Return 0
+	; Target hexed enemy with grouped enemies nearby
+	Local $l_i_Target = UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsHexed")
+	If $l_i_Target <> 0 Then Return $l_i_Target
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3184 - $GC_I_SKILL_ID_ACCUMULATED_PAIN_PVP
@@ -7280,7 +7618,8 @@ Func CanUse_AccumulatedPainPvp()
 EndFunc
 
 Func BestTarget_AccumulatedPainPvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3185 - $GC_I_SKILL_ID_PSYCHIC_INSTABILITY_PVP
@@ -7290,7 +7629,8 @@ Func CanUse_PsychicInstabilityPvp()
 EndFunc
 
 Func BestTarget_PsychicInstabilityPvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3189 - $GC_I_SKILL_ID_SPIRITUAL_PAIN_PVP
@@ -7300,7 +7640,8 @@ Func CanUse_SpiritualPainPvp()
 EndFunc
 
 Func BestTarget_SpiritualPainPvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3194 - $GC_I_SKILL_ID_MIRROR_OF_DISENCHANTMENT_PVP
@@ -7310,7 +7651,8 @@ Func CanUse_MirrorOfDisenchantmentPvp()
 EndFunc
 
 Func BestTarget_MirrorOfDisenchantmentPvp($a_f_AggroRange)
-	Return 0
+	; Target enchanted enemy
+	Return UAI_GetAgentHighest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingEnemy|UAI_Filter_IsEnchanted")
 EndFunc
 
 ; Skill ID: 3197 - $GC_I_SKILL_ID_ADORATION
@@ -7324,7 +7666,8 @@ Func BestTarget_Adoration($a_f_AggroRange)
 	; Spell. Heal target ally 75 Health, and give them a 1% morale boost.
 	; Concise description
 	; Spell. Heals for 75. Grants a 1% morale boost.
-	Return 0
+	; Target: Lowest health ally (support spell)
+	Return UAI_GetAgentLowest(-2, $a_f_AggroRange, $GC_UAI_AGENT_HP, "UAI_Filter_IsLivingAlly")
 EndFunc
 
 ; Skill ID: 3232 - $GC_I_SKILL_ID_HEAL_PARTY_PVP
@@ -7344,7 +7687,8 @@ Func CanUse_ComingOfSpring()
 EndFunc
 
 Func BestTarget_ComingOfSpring($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 3245 - $GC_I_SKILL_ID_DEATHS_EMBRACE
@@ -7354,7 +7698,8 @@ Func CanUse_DeathsEmbrace()
 EndFunc
 
 Func BestTarget_DeathsEmbrace($a_f_AggroRange)
-	Return 0
+	; Self-targeted skill
+	Return UAI_GetPlayerInfo($GC_UAI_AGENT_ID)
 EndFunc
 
 ; Skill ID: 3253 - $GC_I_SKILL_ID_ULTRA_SNOWBALL
@@ -7368,7 +7713,8 @@ Func BestTarget_UltraSnowball($a_f_AggroRange)
 	; Monster
 	; Concise description
 	; deals 100 damage. You gain 1 strike of adrenaline.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3254 - $GC_I_SKILL_ID_BLIZZARD
@@ -7382,7 +7728,8 @@ Func BestTarget_Blizzard($a_f_AggroRange)
 	; Monster
 	; Concise description
 	; Notes">edit
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3259 - $GC_I_SKILL_ID_ULTRA_SNOWBALL2
@@ -7392,7 +7739,8 @@ Func CanUse_UltraSnowball2()
 EndFunc
 
 Func BestTarget_UltraSnowball2($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3260 - $GC_I_SKILL_ID_ULTRA_SNOWBALL3
@@ -7402,7 +7750,8 @@ Func CanUse_UltraSnowball3()
 EndFunc
 
 Func BestTarget_UltraSnowball3($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3261 - $GC_I_SKILL_ID_ULTRA_SNOWBALL4
@@ -7412,7 +7761,8 @@ Func CanUse_UltraSnowball4()
 EndFunc
 
 Func BestTarget_UltraSnowball4($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3262 - $GC_I_SKILL_ID_ULTRA_SNOWBALL5
@@ -7422,7 +7772,8 @@ Func CanUse_UltraSnowball5()
 EndFunc
 
 Func BestTarget_UltraSnowball5($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3272 - $GC_I_SKILL_ID_MYSTIC_HEALING_PVP
@@ -7446,7 +7797,8 @@ Func BestTarget_StunGrenade($a_f_AggroRange)
 	; Spell. Deals 50 Blunt damage to target and adjacent foes. Target and foes in the area are Dazed for 5 seconds and Blinded for 10 seconds.
 	; Concise description
 	; Spell. Target and adjacent foes take 50 Blunt damage. Target and foes in the area are Dazed (5 seconds) and Blinded (10 seconds).
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3291 - $GC_I_SKILL_ID_FRAGMENTATION_GRENADE
@@ -7460,7 +7812,8 @@ Func BestTarget_FragmentationGrenade($a_f_AggroRange)
 	; Spell. Target and adjacent foes take 300 Piercing damage and begin bleeding for 15 seconds. Nearby foes are struck for 200 damage and begin bleeding for 10 seconds. All other foes in the area are struck for 100 damage and begin bleeding for 5 seconds.
 	; Concise description
 	; Spell. Deals 300 Piercing damage and applies Bleeding (15 seconds) to target and adjacent foes. Deals 200 Piercing damage and applies Bleeding (10 seconds) to nearby foes. Deals 100 Piercing damage and applies Bleeding (5 seconds) to other foes in the area.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3292 - $GC_I_SKILL_ID_TEAR_GAS
@@ -7474,7 +7827,8 @@ Func BestTarget_TearGas($a_f_AggroRange)
 	; Spell. Your Tear Gas explodes at target foe's location, striking adjacent foes for 50 fire damage and creating a Smoke Screen for 10 seconds. Foes inside the Smoke Screen suffer from Poison for 10 seconds and cannot cast spells.
 	; Concise description
 	; Spell. Deals 50 fire damage to target and adjacent foes. Creates a Smoke Screen (10 seconds) that applies poison (10 seconds) and prevents spellcasting.
-	Return 0
+	; Target: Grouped enemies (AOE damage)
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3299 - $GC_I_SKILL_ID_PHASED_PLASMA_BURST
@@ -7488,7 +7842,8 @@ Func BestTarget_PhasedPlasmaBurst($a_f_AggroRange)
 	; Spell. Fires a projectile at target enemy. If this projectile hits, target foe takes 100 damage. Nearby foes take 50 damage.
 	; Concise description
 	; Spell. Projectile. Target foe takes 100 damage. Nearby foes takes 50 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3300 - $GC_I_SKILL_ID_PLASMA_SHOT
@@ -7502,7 +7857,8 @@ Func BestTarget_PlasmaShot($a_f_AggroRange)
 	; Spell. Fires a projectile at target enemy. If this projectile hits, target foe takes 75 damage.
 	; Concise description
 	; Spell. Projectile. Target foe takes 75 damage.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3371 - $GC_I_SKILL_ID_MIRROR_SHATTER
@@ -7554,7 +7910,8 @@ Func BestTarget_AnnihilatorBeam($a_f_AggroRange)
 	; Spell. Send out a beam that strikes all targets in a line for 300 damage.
 	; Concise description
 	; Spell. Deals 300 damage to all targets in a line.
-	Return 0
+	; Target: Nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3396 - $GC_I_SKILL_ID_LIGHTNING_HAMMER_PVP
@@ -7564,7 +7921,8 @@ Func CanUse_LightningHammerPvp()
 EndFunc
 
 Func BestTarget_LightningHammerPvp($a_f_AggroRange)
-	Return 0
+	; Target nearest enemy
+	Return UAI_GetNearestAgent(-2, $a_f_AggroRange, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3398 - $GC_I_SKILL_ID_SLIPPERY_GROUND_PVP
@@ -7574,7 +7932,8 @@ Func CanUse_SlipperyGroundPvp()
 EndFunc
 
 Func BestTarget_SlipperyGroundPvp($a_f_AggroRange)
-	Return 0
+	; AOE spell - target grouped enemies
+	Return UAI_GetBestAOETarget(-2, $a_f_AggroRange, $GC_I_RANGE_ADJACENT, "UAI_Filter_IsLivingEnemy")
 EndFunc
 
 ; Skill ID: 3411 - ;  $GC_I_SKILL_ID_UNKNOWN


### PR DESCRIPTION
Added basic targeting for all skills in UtilityAI_Attack, updated UtilityAI_Spell so that many more healing related skills no longer return 0. Updated Hex so now virtually all hexes are supported. Updated Utility_ai skill 10 and 16 to add basic targeting to skills that returned 0.